### PR TITLE
require grpc url and chain id

### DIFF
--- a/src/operator.rs
+++ b/src/operator.rs
@@ -66,8 +66,12 @@ impl<S: Storage + 'static> Operator<S> {
             scheduler,
             queue_executor: QueueExecutor::new(
                 wasmatic_config.chain_kind,
-                wasmatic_config.grpc_url,
-                wasmatic_config.chain_id,
+                wasmatic_config
+                    .grpc_url
+                    .expect("grpc url required when creating queue executor"),
+                wasmatic_config
+                    .chain_id
+                    .expect("chain id required when creating queue executor"),
                 wasmatic_config.gas_denom,
                 wasmatic_config.gas_price,
             ),

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -84,15 +84,15 @@ pub(crate) struct QueueExecutor {
 impl QueueExecutor {
     pub fn new(
         kind: Option<ChainKind>,
-        grpc_url: Option<String>,
-        chain_id: Option<String>,
+        grpc_url: String,
+        chain_id: String,
         gas_denom: Option<String>,
         gas_price: Option<f64>,
     ) -> Self {
         let builder = daemon_builder(
             kind.unwrap_or(ChainKind::Local),
-            grpc_url.unwrap_or("http://localhost:9090".to_string()),
-            chain_id.unwrap_or("slay3r-local".to_string()),
+            grpc_url,
+            chain_id,
             gas_denom.unwrap_or("uslay".to_string()),
             gas_price.unwrap_or(0.025),
         );


### PR DESCRIPTION
Closes #18 

Requires grpc and chain id are provided, either via wasmatic.toml or command line argument.  Command line will take precedence over wasmatic.toml when both are provided.

I also took a look at making `pub_address_prefix` configurable, but it turns out that the `daemon_builder` requires the `NetworkInfo` to be a static argument, so configuring would require a `mut static` which would bubble up some `unsafe` blocks.  I figured better to leave as is for now, and that this could make more sense to include when we migrate to `climb` from `cw_orch`.