### PR TITLE
First attempt to auto-build images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,9 @@ on:
       - 'v*'
     branches:
       - main
-  pull_request:
-    branches:
-      - main
+  # pull_request:
+  #   branches:
+  #     - main
 
 env:
   REGISTRY: ghcr.io
@@ -52,17 +52,18 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          # push: ${{ github.event_name != 'pull_request' }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
+      # Enable this on public repo
+      # - name: Generate artifact attestation
+      #   uses: actions/attest-build-provenance@v1
+      #   with:
+      #     subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+      #     subject-digest: ${{ steps.push.outputs.digest }}
+      #     push-to-registry: true
+
 
 # This is some rough code for multi-arch builds...
 # Use this as a basis later


### PR DESCRIPTION
This is a process. We may not finish it all in this PR:

- [x] Build docker image on amd64 and push "latest" to ghcr.io
- [x] Configure to only push on git tags, and also tag the release the same, minus v (git `v0.2.1` -> docker: `:0.2.1`)

Later: 

- [ ] Build multi-arch (ideally on multiple runners), so it is available for arm64 and amd64. Check out [this example](https://docs.docker.com/build/ci/github-actions/multi-platform/)

This tags `ghcr.io/lay3rlabs/wasmatic:main` on each merge to `main`
And tags `0.2.1` and `0.2` (and `latest`?) when the `v0.2.1` tags is pushed 