### PR TITLE
Add mock trigger manager

### DIFF
--- a/src/apis/trigger.rs
+++ b/src/apis/trigger.rs
@@ -31,7 +31,7 @@ pub struct TriggerData {
 }
 
 /// The data returned from a trigger action
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct TriggerAction {
     /// Identify which service and workflow this came from
     pub service_id: ID,
@@ -42,7 +42,7 @@ pub struct TriggerAction {
 }
 
 /// This is the actual data we got from the trigger, used to feed into the component
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum TriggerResult {
     Queue {
         /// The id from the task queue


### PR DESCRIPTION
Builds on #87 (merge that first)

This lets us create a simple mock that either:

* Pushes a given list of TriggerActions to the channel and closes
* Returns errors when called (to test error handling logic)

Not implemented: store realistic state for add/remove triggers. It just says `Ok(())`

This should be enough to start testing pipeline workflows.
Next up - mocking the engine