### PR TITLE
config-refactor

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -59,4 +59,4 @@ _Tip!_: For setting env vars, all the tooling is `.env` file aware, from whereve
     - deploy the contracts: `cargo run -- --target=local deploy -m verifier-simple contracts --operators wasmatic`
     - take the LOCAL_TASK_QUEUE_ADDRESS value, and set it in the `WAVS_E2E_LAYER_TASK_QUEUE_ADDRESS` env var
 6. Kill the localnode's wasmatic instance to make sure we're hitting the test instance only: `docker stop localnode-wasmatic-1`
-7. In this repo, run the tests: `cargo test --features e2e_tests,e2e_tests_layer`
+7. In this repo, run the tests: `cargo test --features e2e_tests,e2e_tests_cosmos`

--- a/packages/cli/src/args.rs
+++ b/packages/cli/src/args.rs
@@ -1,4 +1,4 @@
-use clap::{Args, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -10,9 +10,8 @@ use utils::{
     eigen_client::{CoreAVSAddresses, EigenClient},
     eth_client::{EthClientBuilder, EthClientConfig},
     hello_world::{
-        config::HelloWorldAddresses,
         solidity_types::hello_world::HelloWorldServiceManager::NewTaskCreated,
-        HelloWorldFullClient, HelloWorldFullClientBuilder, HelloWorldSimpleClient,
+        HelloWorldFullClient, HelloWorldFullClientBuilder,
     },
 };
 

--- a/packages/wavs/Cargo.toml
+++ b/packages/wavs/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/Lay3rLabs/wasmatic"
 
 [features]
 e2e_tests = []
-e2e_tests_layer = ["e2e_tests"]
+e2e_tests_cosmos = ["e2e_tests"]
 e2e_tests_ethereum = ["e2e_tests"]
 
 [dependencies]

--- a/packages/wavs/src/apis/dispatcher.rs
+++ b/packages/wavs/src/apis/dispatcher.rs
@@ -99,8 +99,7 @@ pub struct Workflow {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum Submit {
-    /// Writing a transaction directly to the verifier contract on the layer chain
-    /// the node is configured for.
+    /// Writing a transaction directly to the layer verifier contract
     LayerVerifierTx {
         /// The hd index of the mnemonic to sign with
         hd_index: u32,

--- a/packages/wavs/src/apis/submission.rs
+++ b/packages/wavs/src/apis/submission.rs
@@ -39,8 +39,8 @@ pub enum SubmissionError {
     Reqwest(reqwest::Error),
     #[error("faucet: {0}")]
     Faucet(String),
-    #[error("missing layer chain")]
-    MissingLayerChain,
+    #[error("missing cosmos chain")]
+    MissingCosmosChain,
     #[error("ethereum: {0}")]
     Ethereum(anyhow::Error),
     #[error("missing ethereum chain")]

--- a/packages/wavs/src/args.rs
+++ b/packages/wavs/src/args.rs
@@ -65,17 +65,17 @@ pub struct CliArgs {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wasm_threads: Option<usize>,
 
-    /// The ethereum chain to use for the application
+    /// The Ethereum-style chain to use for the application
     /// will load from the config file
     #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub chain: Option<String>,
 
-    /// The layer chain to use for the application
+    /// The Cosmos-style chain to use for the application
     /// will load from the config file
     #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub layer_chain: Option<String>,
+    pub cosmos_chain: Option<String>,
 
     #[clap(flatten)]
     #[serde(flatten)]
@@ -83,8 +83,13 @@ pub struct CliArgs {
 }
 
 // used in both config and cli/env args
+// because it is flattened, we need to use prefixes to avoid conflicts
 #[derive(Parser, Clone, Debug, Serialize, Deserialize, Default)]
 pub struct OptionalWavsChainConfig {
+    /// To override the chosen eth chain's chain_id
+    #[arg(long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chain_id: Option<String>,
     /// To override the chosen eth chain's ws_endpoint
     #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -97,34 +102,43 @@ pub struct OptionalWavsChainConfig {
     #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub submission_mnemonic: Option<String>,
-    /// To override the chosen layer chain's chain_id
+    /// To override the chosen eth chain's submission mnemonic
     #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub layer_chain_id: Option<ChainId>,
-    /// To override the chosen layer chain's rpc_endpoint
+    pub faucet_endpoint: Option<String>,
+
+    /// To override the chosen cosmos chain's chain_id
     #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub layer_rpc_endpoint: Option<String>,
-    /// To override the chosen layer chain's grpc_endpoint
+    pub cosmos_chain_id: Option<ChainId>,
+    /// To override the chosen cosmos chain's bech32_prefix
     #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub layer_grpc_endpoint: Option<String>,
-    /// To override the chosen layer chain's gas_price
+    pub cosmos_bech32_prefix: Option<ChainId>,
+    /// To override the chosen cosmos chain's rpc_endpoint
     #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub layer_gas_price: Option<f32>,
-    /// To override the chosen layer chain's gas_denom
+    pub cosmos_rpc_endpoint: Option<String>,
+    /// To override the chosen cosmos chain's grpc_endpoint
     #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub layer_gas_denom: Option<String>,
-    /// To override the chosen layer chain's faucet_endpoint
+    pub cosmos_grpc_endpoint: Option<String>,
+    /// To override the chosen cosmos chain's gas_price
     #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub layer_faucet_endpoint: Option<String>,
-    /// To override the chosen layer chain's submission mnemonic
+    pub cosmos_gas_price: Option<f32>,
+    /// To override the chosen cosmos chain's gas_denom
     #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub layer_submission_mnemonic: Option<String>,
+    pub cosmos_gas_denom: Option<String>,
+    /// To override the chosen cosmos chain's faucet_endpoint
+    #[arg(long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cosmos_faucet_endpoint: Option<String>,
+    /// To override the chosen cosmos chain's submission mnemonic
+    #[arg(long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cosmos_submission_mnemonic: Option<String>,
 }
 
 impl CliArgs {

--- a/packages/wavs/src/http/handlers/info.rs
+++ b/packages/wavs/src/http/handlers/info.rs
@@ -21,16 +21,16 @@ pub async fn handle_info(State(state): State<HttpState>) -> impl IntoResponse {
 pub async fn inner_handle_info(state: HttpState) -> HttpResult<InfoResponse> {
     // TODO - get the operators from the dispatcher, and/or Eigenlayer?
 
-    let layer_chain_config = state.config.layer_chain_config()?;
+    let cosmos_chain_config = state.config.cosmos_chain_config()?;
 
-    let mnemonic = layer_chain_config
+    let mnemonic = cosmos_chain_config
         .submission_mnemonic
         .clone()
         .context("submission_mnemonic not set")?;
 
     let mut operators = Vec::new();
 
-    let climb_address_kind = ChainConfig::from(layer_chain_config).address_kind;
+    let climb_address_kind = ChainConfig::from(cosmos_chain_config).address_kind;
 
     for i in 0..10 {
         let key_signer =

--- a/packages/wavs/src/test_utils/app.rs
+++ b/packages/wavs/src/test_utils/app.rs
@@ -33,7 +33,7 @@ impl TestApp {
             data: None,
             cors_allowed_origins: Vec::new(),
             chain: None,
-            layer_chain: None,
+            cosmos_chain: None,
             chain_config: Default::default(),
             wasm_lru_size: None,
             wasm_threads: None,

--- a/packages/wavs/tests/config.rs
+++ b/packages/wavs/tests/config.rs
@@ -178,32 +178,29 @@ async fn config_dotenv() {
 async fn config_chains() {
     let config = TestApp::new().await.config;
 
-    let chain_config = config.layer_chain_config().unwrap();
-    assert_eq!(chain_config.chain_id, "slay3r-local".parse().unwrap());
+    let chain_config = config.cosmos_chain_config().unwrap();
+    assert_eq!(chain_config.chain_id, "layer-local");
 
     // change the target chain via cli
     let mut cli_args = TestApp::default_cli_args();
-    cli_args.layer_chain = Some("testnet".to_string());
+    cli_args.cosmos_chain = Some("layer-hacknet".to_string());
     let config = TestApp::new_with_args(cli_args).await.config;
-    let chain_config = config.layer_chain_config().unwrap();
-    assert_eq!(
-        chain_config.chain_id,
-        "layer-permissionless-3".parse().unwrap()
-    );
+    let chain_config = config.cosmos_chain_config().unwrap();
+    assert_eq!(chain_config.chain_id, "layer-hack-1");
 
     // change the rpc endpoint for cosmos
     let mut cli_args = TestApp::default_cli_args();
-    cli_args.chain_config.layer_rpc_endpoint = Some("http://example.com:1234".to_string());
+    cli_args.chain_config.cosmos_rpc_endpoint = Some("http://example.com:1234".to_string());
     cli_args.chain_config.http_endpoint = Some("THIS-ISN'T-USED".to_string());
     let config = TestApp::new_with_args(cli_args).await.config;
-    let chain_config = config.layer_chain_config().unwrap();
+    let chain_config = config.cosmos_chain_config().unwrap();
     assert_eq!(chain_config.rpc_endpoint, "http://example.com:1234");
 
     // change the http endpoint for ethereum
     let mut cli_args = TestApp::default_cli_args();
-    cli_args.chain_config.layer_rpc_endpoint = Some("THIS-ISN'T-USED".to_string());
+    cli_args.chain_config.cosmos_rpc_endpoint = Some("THIS-ISN'T-USED".to_string());
     cli_args.chain_config.http_endpoint = Some("http://example.com:1234".to_string());
-    cli_args.chain = Some("local-eth".to_string());
+    cli_args.chain = Some("local".to_string());
     let config = TestApp::new_with_args(cli_args).await.config;
     let chain_config = config.ethereum_chain_config().unwrap();
     assert_eq!(chain_config.http_endpoint, "http://example.com:1234");

--- a/packages/wavs/tests/e2e.rs
+++ b/packages/wavs/tests/e2e.rs
@@ -3,21 +3,21 @@
 
 #[cfg(feature = "e2e_tests")]
 mod e2e {
+    mod cosmos;
     mod eth;
     mod http;
-    mod layer;
 
     use std::{path::PathBuf, sync::Arc, time::Duration};
 
     use alloy::node_bindings::{Anvil, AnvilInstance};
     use anyhow::bail;
+    use cosmos::CosmosTestApp;
     use eth::EthTestApp;
     use http::HttpClient;
     use lavs_apis::{
         events::{task_queue_events::TaskCreatedEvent, traits::TypedEvent},
         tasks as task_queue,
     };
-    use layer::LayerTestApp;
     use layer_climb::prelude::*;
     use serde::{Deserialize, Serialize};
     use wavs::{
@@ -55,10 +55,10 @@ mod e2e {
         };
 
         cfg_if::cfg_if! {
-            if #[cfg(feature = "e2e_tests_layer")] {
-                config.layer_chain = Some(config.layer_chain.clone().unwrap());
+            if #[cfg(feature = "e2e_tests_cosmos")] {
+                config.cosmos_chain = Some(config.cosmos_chain.clone().unwrap());
             } else {
-                config.layer_chain = None;
+                config.cosmos_chain = None;
             }
         }
 
@@ -129,9 +129,9 @@ mod e2e {
                             }
                         };
 
-                        match (config.layer_chain.is_some(), config.chain.is_some()) {
+                        match (config.cosmos_chain.is_some(), config.chain.is_some()) {
                             (true, false) => {
-                                run_tests_layer(http_client, config, permissions_wasm_digest).await
+                                run_tests_cosmos(http_client, config, permissions_wasm_digest).await
                             }
                             (false, true) => {
                                 run_tests_ethereum(
@@ -228,10 +228,10 @@ mod e2e {
         // TODO!
     }
 
-    async fn run_tests_layer(http_client: HttpClient, config: Config, wasm_digest: Digest) {
-        tracing::info!("Running e2e layer tests");
+    async fn run_tests_cosmos(http_client: HttpClient, config: Config, wasm_digest: Digest) {
+        tracing::info!("Running e2e cosmos tests");
 
-        let app = LayerTestApp::new(config).await;
+        let app = CosmosTestApp::new(config).await;
 
         let service_id = ID::new("test-service").unwrap();
 

--- a/packages/wavs/tests/e2e/cosmos.rs
+++ b/packages/wavs/tests/e2e/cosmos.rs
@@ -5,13 +5,13 @@ use serde::Serialize;
 use wavs::config::Config;
 
 #[allow(dead_code)]
-pub struct LayerTestApp {
+pub struct CosmosTestApp {
     pub layer_client: SigningClient,
     pub task_queue: LayerTaskQueueContract,
     pub verifier_addr: Address,
 }
 
-impl LayerTestApp {
+impl CosmosTestApp {
     pub async fn new(config: Config) -> Self {
         // get all env vars
         let seed_phrase =
@@ -19,7 +19,7 @@ impl LayerTestApp {
         let task_queue_addr = std::env::var("WAVS_E2E_LAYER_TASK_QUEUE_ADDRESS")
             .expect("WAVS_E2E_LAYER_TASK_QUEUE_ADDRESS not set");
 
-        let chain_config: ChainConfig = config.layer_chain_config().unwrap().into();
+        let chain_config: ChainConfig = config.cosmos_chain_config().unwrap().into();
 
         let key_signer = KeySigner::new_mnemonic_str(&seed_phrase, None).unwrap();
         let signing_client = SigningClient::new(chain_config.clone(), key_signer)

--- a/packages/wavs/tests/wavs/wavs.toml
+++ b/packages/wavs/tests/wavs/wavs.toml
@@ -2,25 +2,60 @@
 
 log_level = ["info", "wavs=debug", "just_to_confirm_test=debug"]
 
-layer_chain = "local-layer"
-chain = "local-eth"
+# chosen eth chain name 
+chain = "local"
 
-[chains.local-layer]
-chain_kind = "cosmos"
-chain_id = "slay3r-local"
+# chosen cosmos chain name 
+cosmos_chain = "layer-local"
+
+[chains.cosmos.layer-local]
+chain_id = "layer-local"
+bech32_prefix = "layer"
 rpc_endpoint = "http://localhost:26657"
 grpc_endpoint = "http://localhost:9090"
 gas_price = 0.025
+gas_denom = "ulayer"
+faucet_endpoint = "http://localhost:8000"
 
-[chains.testnet]
-chain_kind = "cosmos"
-chain_id = "layer-permissionless-3"
-rpc_endpoint = "https://rpc.layer-p.net"
-grpc_endpoint = "https://grpc.layer-p.net:443"
+# localnode is local testing inside localnode docker-compose network
+[chains.cosmos.layer-localnode]
+chain_id = "layer-local"
+bech32_prefix = "layer"
+rpc_endpoint = "http://layer:26657"
+grpc_endpoint = "http://layer:9090"
 gas_price = 0.025
-gas_denom = "uperm"
+gas_denom = "ulayer"
+faucet_endpoint = "http://faucet:8000"
 
-[chains.local-eth]
-chain_kind = "ethereum"
+# hacknet is our public facing pseudo-testnet for hackathons
+[chains.cosmos.layer-hacknet]
+chain_id = "layer-hack-1"
+bech32_prefix = "layer"
+rpc_endpoint = "https://rpc.hack.layer.xyz:443"
+grpc_endpoint = "https://grpc.hack.layer.xyz:443"
+gas_price = 0.025
+gas_denom = "ulayer"
+faucet_endpoint = "https://rabbit.hack.layer.xyz"
+
+[chains.cosmos.neutron]
+chain_id = "pion-1"
+bech32_prefix = "neutron"
+rpc_endpoint = "https://rpc-falcron.pion-1.ntrn.tech"
+grpc_endpoint = "http://grpc-falcron.pion-1.ntrn.tech:80"
+gas_price = 0.0053
+gas_denom = "untrn"
+
+[chains.eth.local]
+chain_id = "31337"
 ws_endpoint = "ws://localhost:8545"
 http_endpoint = "http://localhost:8545"
+
+[chains.eth.sepolia]
+chain_id = "11155111"
+ws_endpoint = "wss://ethereum-sepolia-rpc.publicnode.com"
+http_endpoint = "https://ethereum-sepolia-rpc.publicnode.com"
+
+[chains.eth.holesky]
+chain_id = "17000"
+ws_endpoint = "wss://ethereum-holesky-rpc.publicnode.com"
+http_endpoint = "https://ethereum-holesky-rpc.publicnode.com"

--- a/packages/wavs/wavs.toml
+++ b/packages/wavs/wavs.toml
@@ -25,14 +25,15 @@ cors_allowed_origins = [
 # the directory to store the data. Default is "/var/wavs"
 # data = "~/wavs/data"
 
-# chosen chain name 
-# chain = "localnode"
+# chosen eth chain name 
+chain = "local"
 
-# chain config
-# localhost is local testing when you run the image outside of the docker-compose network
-[chains.localhost]
-chain_kind = "cosmos"
+# chosen cosmos chain name 
+cosmos_chain = "layer-local"
+
+[chains.cosmos.layer-local]
 chain_id = "layer-local"
+bech32_prefix = "layer"
 rpc_endpoint = "http://localhost:26657"
 grpc_endpoint = "http://localhost:9090"
 gas_price = 0.025
@@ -40,9 +41,9 @@ gas_denom = "ulayer"
 faucet_endpoint = "http://localhost:8000"
 
 # localnode is local testing inside localnode docker-compose network
-[chains.localnode]
-chain_kind = "cosmos"
+[chains.cosmos.layer-localnode]
 chain_id = "layer-local"
+bech32_prefix = "layer"
 rpc_endpoint = "http://layer:26657"
 grpc_endpoint = "http://layer:9090"
 gas_price = 0.025
@@ -50,26 +51,34 @@ gas_denom = "ulayer"
 faucet_endpoint = "http://faucet:8000"
 
 # hacknet is our public facing pseudo-testnet for hackathons
-[chains.hacknet]
-chain_kind = "cosmos"
+[chains.cosmos.layer-hacknet]
 chain_id = "layer-hack-1"
+bech32_prefix = "layer"
 rpc_endpoint = "https://rpc.hack.layer.xyz:443"
 grpc_endpoint = "https://grpc.hack.layer.xyz:443"
 gas_price = 0.025
 gas_denom = "ulayer"
 faucet_endpoint = "https://rabbit.hack.layer.xyz"
 
-# hacknet is our public facing pseudo-testnet for hackathons
-[chains.demonet]
-chain_kind = "cosmos"
-chain_id = "layer-demo-1"
-rpc_endpoint = "https://rpc.demo.layer.xyz:443"
-grpc_endpoint = "https://grpc.demo.layer.xyz:443"
-gas_price = 0.025
-gas_denom = "ulayer"
-faucet_endpoint = "https://faucet.demo.layer.xyz"
+[chains.cosmos.neutron]
+chain_id = "pion-1"
+bech32_prefix = "neutron"
+rpc_endpoint = "https://rpc-falcron.pion-1.ntrn.tech"
+grpc_endpoint = "http://grpc-falcron.pion-1.ntrn.tech:80"
+gas_price = 0.0053
+gas_denom = "untrn"
 
-[chains.local-eth]
-chain_kind = "ethereum"
+[chains.eth.local]
+chain_id = "31337"
 ws_endpoint = "ws://localhost:8545"
 http_endpoint = "http://localhost:8545"
+
+[chains.eth.sepolia]
+chain_id = "11155111"
+ws_endpoint = "wss://ethereum-sepolia-rpc.publicnode.com"
+http_endpoint = "https://ethereum-sepolia-rpc.publicnode.com"
+
+[chains.eth.holesky]
+chain_id = "17000"
+ws_endpoint = "wss://ethereum-holesky-rpc.publicnode.com"
+http_endpoint = "https://ethereum-holesky-rpc.publicnode.com"


### PR DESCRIPTION
In addition to the overall config refactor as per the issue, I renamed things a bit internally:

"cosmos" is for cosmos-flavored chains, "layer" is for layer-specific stuff. 

As a proof-of-concept so it all makes sense, I added Neutron to the config to have another cosmos-flavored chain aside for layer, and the Verifier submission is still LayerVerifierTx since that's a Layer-specific concept.

Ofc if we one day have a non-cosmos layer-sdk chain, we can now easily add that as a new type in addition to "eth" and "cosmos"

* closes #181 