### PR TITLE
fix: add `packages/aggregator` dependency to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /myapp
 
 # This whole pile will pre-build and cache the dependencies, so we just recompile local code below
 COPY Cargo.lock Cargo.toml /myapp/
+COPY packages/aggregator /myapp/packages/aggregator
 COPY packages/wavs/Cargo.toml /myapp/packages/wavs/Cargo.toml
 COPY packages/utils/Cargo.toml /myapp/packages/utils/Cargo.toml
 COPY dummy.rs /myapp/packages/wavs/benches/mock_bench.rs
@@ -17,7 +18,7 @@ RUN rm /myapp/packages/utils/src/*.rs
 RUN rm -rf target/release/.fingerprint/wavs*
 
 # This build step should just compile the local code and be faster
-COPY . . 
+COPY . .
 RUN cargo build --manifest-path /myapp/packages/wavs/Cargo.toml --release
 
 ### PRODUCTION


### PR DESCRIPTION
## Summary

title. found from failing main. CI will be built in the near future to resolve this sort of problem (#231) when we have a docker/e2e workflow.

## Context

introduced in: https://github.com/Lay3rLabs/WAVS/pull/221/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542

![image](https://github.com/user-attachments/assets/ad8fefdb-58b3-4462-a850-6ff34814cfdd)

## Verification

`just docker-build` from main, then `just docker-build` here (works here, fails main)
