### PR TITLE
refactor: use 127.0.0.1 and not localhost

### DIFF
--- a/examples/eth-cosmos-query/src/lib.rs
+++ b/examples/eth-cosmos-query/src/lib.rs
@@ -31,7 +31,7 @@ fn process_eth_trigger(input: Vec<u8>) -> std::result::Result<Vec<u8>, String> {
 fn handle_request(req: CosmosQueryRequest) -> Result<CosmosQueryResponse> {
     let chain_config = ChainConfig {
         chain_id: "local-osmosis".parse().unwrap(),
-        rpc_endpoint: Some("http://localhost:26657".to_string()),
+        rpc_endpoint: Some("http://127.0.0.1:26657".to_string()),
         grpc_endpoint: None,
         grpc_web_endpoint: None,
         gas_price: 0.025,

--- a/packages/aggregator/src/config.rs
+++ b/packages/aggregator/src/config.rs
@@ -24,7 +24,7 @@ pub struct Config {
     /// Default is `["info"]`
     pub log_level: Vec<String>,
     /// The host to bind the server to
-    /// Default is `localhost`
+    /// Default is `127.0.0.1`
     pub host: String,
     /// The directory to store all internal data files
     /// Default is `/var/aggregator`
@@ -56,7 +56,7 @@ impl Default for Config {
         Self {
             port: 8001,
             log_level: vec!["info".to_string()],
-            host: "localhost".to_string(),
+            host: "127.0.0.1".to_string(),
             data: PathBuf::from("/var/aggregator"),
             cors_allowed_origins: Vec::new(),
             mnemonic: None,

--- a/packages/utils/src/config.rs
+++ b/packages/utils/src/config.rs
@@ -615,11 +615,11 @@ mod test {
             CosmosChainConfig {
                 chain_id: "eth".to_string(),
                 bech32_prefix: "eth".to_string(),
-                rpc_endpoint: Some("http://localhost:1317".to_string()),
-                grpc_endpoint: Some("http://localhost:9090".to_string()),
+                rpc_endpoint: Some("http://127.0.0.1:1317".to_string()),
+                grpc_endpoint: Some("http://127.0.0.1:9090".to_string()),
                 gas_price: 0.01,
                 gas_denom: "uatom".to_string(),
-                faucet_endpoint: Some("http://localhost:8000".to_string()),
+                faucet_endpoint: Some("http://127.0.0.1:8000".to_string()),
             },
         );
 
@@ -634,11 +634,11 @@ mod test {
                     CosmosChainConfig {
                         chain_id: "cosmos".to_string(),
                         bech32_prefix: "cosmos".to_string(),
-                        rpc_endpoint: Some("http://localhost:1317".to_string()),
-                        grpc_endpoint: Some("http://localhost:9090".to_string()),
+                        rpc_endpoint: Some("http://127.0.0.1:1317".to_string()),
+                        grpc_endpoint: Some("http://127.0.0.1:9090".to_string()),
                         gas_price: 0.01,
                         gas_denom: "uatom".to_string(),
-                        faucet_endpoint: Some("http://localhost:8000".to_string()),
+                        faucet_endpoint: Some("http://127.0.0.1:8000".to_string()),
                     },
                 ),
                 (
@@ -646,11 +646,11 @@ mod test {
                     CosmosChainConfig {
                         chain_id: "layer".to_string(),
                         bech32_prefix: "layer".to_string(),
-                        rpc_endpoint: Some("http://localhost:1317".to_string()),
-                        grpc_endpoint: Some("http://localhost:9090".to_string()),
+                        rpc_endpoint: Some("http://127.0.0.1:1317".to_string()),
+                        grpc_endpoint: Some("http://127.0.0.1:9090".to_string()),
                         gas_price: 0.01,
                         gas_denom: "uatom".to_string(),
-                        faucet_endpoint: Some("http://localhost:8000".to_string()),
+                        faucet_endpoint: Some("http://127.0.0.1:8000".to_string()),
                     },
                 ),
             ]
@@ -661,20 +661,20 @@ mod test {
                     "eth".to_string(),
                     EthereumChainConfig {
                         chain_id: "eth".to_string(),
-                        ws_endpoint: "ws://localhost:8546".to_string(),
-                        http_endpoint: "http://localhost:8545".to_string(),
-                        aggregator_endpoint: Some("http://localhost:8000".to_string()),
-                        faucet_endpoint: Some("http://localhost:8000".to_string()),
+                        ws_endpoint: "ws://127.0.0.1:8546".to_string(),
+                        http_endpoint: "http://127.0.0.1:8545".to_string(),
+                        aggregator_endpoint: Some("http://127.0.0.1:8000".to_string()),
+                        faucet_endpoint: Some("http://127.0.0.1:8000".to_string()),
                     },
                 ),
                 (
                     "polygon".to_string(),
                     EthereumChainConfig {
                         chain_id: "polygon".to_string(),
-                        ws_endpoint: "ws://localhost:8546".to_string(),
-                        http_endpoint: "http://localhost:8545".to_string(),
-                        aggregator_endpoint: Some("http://localhost:8000".to_string()),
-                        faucet_endpoint: Some("http://localhost:8000".to_string()),
+                        ws_endpoint: "ws://127.0.0.1:8546".to_string(),
+                        http_endpoint: "http://127.0.0.1:8545".to_string(),
+                        aggregator_endpoint: Some("http://127.0.0.1:8000".to_string()),
+                        faucet_endpoint: Some("http://127.0.0.1:8000".to_string()),
                     },
                 ),
             ]

--- a/packages/wavs/src/config.rs
+++ b/packages/wavs/src/config.rs
@@ -18,7 +18,7 @@ pub struct Config {
     /// Default is `["info"]`
     pub log_level: Vec<String>,
     /// The host to bind the server to
-    /// Default is `localhost`
+    /// Default is `127.0.0.1`
     pub host: String,
     /// The directory to store all internal data files
     /// Default is `/var/wavs`
@@ -71,7 +71,7 @@ impl Default for Config {
         Self {
             port: 8000,
             log_level: vec!["info".to_string()],
-            host: "localhost".to_string(),
+            host: "127.0.0.1".to_string(),
             data: PathBuf::from("/var/wavs"),
             cors_allowed_origins: Vec::new(),
             cosmos_chain: None,

--- a/packages/wavs/src/triggers/core.rs
+++ b/packages/wavs/src/triggers/core.rs
@@ -597,9 +597,9 @@ mod tests {
                     "test-eth".to_string(),
                     EthereumChainConfig {
                         chain_id: "eth-local".parse().unwrap(),
-                        ws_endpoint: "ws://localhost:26657".to_string(),
-                        http_endpoint: "http://localhost:26657".to_string(),
-                        aggregator_endpoint: Some("http://localhost:8001".to_string()),
+                        ws_endpoint: "ws://127.0.0.1:26657".to_string(),
+                        http_endpoint: "http://127.0.0.1:26657".to_string(),
+                        aggregator_endpoint: Some("http://127.0.0.1:8001".to_string()),
                         faucet_endpoint: None,
                     },
                 )]
@@ -609,8 +609,8 @@ mod tests {
                     "test-cosmos".to_string(),
                     CosmosChainConfig {
                         chain_id: "layer-local".parse().unwrap(),
-                        rpc_endpoint: Some("http://localhost:26657".to_string()),
-                        grpc_endpoint: Some("http://localhost:9090".to_string()),
+                        rpc_endpoint: Some("http://127.0.0.1:26657".to_string()),
+                        grpc_endpoint: Some("http://127.0.0.1:9090".to_string()),
                         gas_price: 0.025,
                         gas_denom: "uslay".to_string(),
                         bech32_prefix: "layer".to_string(),


### PR DESCRIPTION
## Summary

127.0.0.1 is faster and does not require a /etc/host lookup. Further, localhost references both the ipv6 (::1) and standard ipv4, in that order. meaning request always try to ipv6 first (possibly even multiple ipv6 attempts). 

This can save up to ~2-3% in network latency and avoid ipv6 bugs in the future.