### PR TITLE
Update required rust version 1.84

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.83.0
+          toolchain: 1.84.0
           #   target: wasm32-unknown-unknown
           override: true
 
@@ -64,7 +64,7 @@ jobs:
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
-          toolchain: 1.83.0
+          toolchain: 1.84.0
           command: test
           args: --workspace --locked -- --nocapture
         env:
@@ -82,7 +82,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.83.0
+          toolchain: 1.84.0
           override: true
           components: rustfmt, clippy
 
@@ -105,13 +105,13 @@ jobs:
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
         with:
-          toolchain: 1.83.0
+          toolchain: 1.84.0
           command: fmt
           args: --all -- --check
 
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
         with:
-          toolchain: 1.83.0
+          toolchain: 1.84.0
           command: clippy
           args: --all-targets -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 version = "0.2.0"
 license = "MIT"
 authors = ["Lay3r Labs Team"]
-repository = "https://github.com/Lay3rLabs/wasmatic"
-rust-version = "1.80.0"
+repository = "https://github.com/Lay3rLabs/WAVS"
+rust-version = "1.84.0"
 
 [workspace.dependencies]
 utils = { path = "packages/utils" }


### PR DESCRIPTION
Recently we updated docker-compose to rustc 1.84; let's make it the same in CI and Cargo.