### PR TITLE
standardize api casing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7306,7 +7306,7 @@ dependencies = [
 
 [[package]]
 name = "wavs-types"
-version = "0.3.0-alpha1"
+version = "0.3.0-alpha2"
 dependencies = [
  "alloy-primitives",
  "const-hex",

--- a/packages/aggregator/src/http/handlers/info.rs
+++ b/packages/aggregator/src/http/handlers/info.rs
@@ -4,7 +4,7 @@ use axum::{extract::State, response::IntoResponse, Json};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct InfoResponse {
     pub signer_address: alloy::primitives::Address,
     pub signer_balance: String,

--- a/packages/types/Cargo.toml
+++ b/packages/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavs-types"
-version = "0.3.0-alpha1"
+version = "0.3.0-alpha2"
 description = "WAVS Types"
 edition.workspace = true
 authors.workspace = true

--- a/packages/types/src/service.rs
+++ b/packages/types/src/service.rs
@@ -144,7 +144,7 @@ impl TriggerData {
 
 // TODO - rename this? Trigger is a noun, Submit is a verb.. feels a bit weird
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub enum Submit {
     // useful for when the component just does something with its own state
     None,
@@ -157,7 +157,7 @@ pub enum Submit {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct ServiceConfig {
     /// The maximum amount of compute metering to allow for a single execution
     pub fuel_limit: u64,

--- a/packages/wavs/src/http/handlers/info.rs
+++ b/packages/wavs/src/http/handlers/info.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use utils::config::AnyChainConfig;
 
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct InfoResponse {
     pub operators: Vec<String>,
 }


### PR DESCRIPTION
Breaking change - standardizes the API with `snake_case`, gets rid of `camelCase`

(the point isn't _necessarily_ one vs. the other, but rather to have one standard. in terms of which - imho `snake_case` is easier to read / is more flexible when you want to use capital letters to signal more than a new word, e.g. `foo_AVS`... but I wouldn't block this PR on that debate, after this is in we can decide to switch it with a global search/replace, right now it's a mixture)

accidentally published the updates `wavs-types` crate to crates.io already (bumped to alpha2), in the future will wait for PR to land 😅 