### PR TITLE
publish-solidity

### DIFF
--- a/contracts/solidity/package.json
+++ b/contracts/solidity/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@wavs/solidity",
+  "version": "0.3.0-alpha2",
+  "description": "WAVS Solidity contracts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "interfaces/"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Lay3rLabs/WAVS.git"
+  },
+  "author": "Lay3r Labs Team",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Lay3rLabs/WAVS/issues"
+  },
+  "homepage": "https://github.com/Lay3rLabs/WAVS#readme"
+}


### PR DESCRIPTION
* closes #371 

Intentionally only publishes the interfaces - this allows consumers to just pull it in and not need to deal with our actual contracts and all the remappings to make those work.

Tested and proven in https://github.com/Lay3rLabs/example-cosmos-eth-bridge/tree/main/contracts/solidity and https://github.com/Lay3rLabs/example-telegram-bot/tree/main/solidity/contracts which each `npm install @wavs/solidity`