### PR TITLE
refactor: make `--trigger` flag optional by inferring from trigger_address

### DIFF
--- a/packages/cli/src/args.rs
+++ b/packages/cli/src/args.rs
@@ -49,6 +49,11 @@ pub enum Command {
         #[clap(long)]
         component: String,
 
+        /// The kind of trigger to deploy
+        /// If not set, will assume the trigger from the trigger_address
+        #[clap(long)]
+        trigger: Option<CliTriggerKind>,
+
         /// The will be event name for cosmos triggers, hex-encoded event signature for eth triggers
         #[clap(long, required_if_eq_any([
             ("trigger", CliTriggerKind::EthContractEvent),

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -54,6 +54,7 @@ async fn main() {
         }
         Command::DeployService {
             component,
+            trigger,
             trigger_chain,
             trigger_address,
             submit_address,
@@ -65,15 +66,18 @@ async fn main() {
         } => {
             let component = ComponentSource::Bytecode(read_component(&component).unwrap());
 
-            let trigger = match &trigger_address {
-                Some(trigger_address) => {
+            let trigger = match (trigger, &trigger_address) {
+                (Some(trigger), _) => trigger,
+                (None, Some(trigger_address)) => {
                     if trigger_address.starts_with("0x") {
                         CliTriggerKind::EthContractEvent
                     } else {
                         CliTriggerKind::CosmosContractEvent
                     }
                 }
-                None => CliTriggerKind::CosmosContractEvent,
+                (None, None) => {
+                    panic!("trigger is required to be set if trigger_address is not set");
+                }
             };
 
             let res = DeployService::run(


### PR DESCRIPTION
closes #319

## Summary

Users already provide a `--trigger-address` which is either a 0x or cosmos1 address. If 0x, we know the events will be Eth. Else, it's a cosmos event. We now infer this for the user, removing duplicated input.