### PR TITLE
WIP: Ethan experiments with dev-workspace

### DIFF
--- a/docker/dev-desktop/docker-compose.yml
+++ b/docker/dev-desktop/docker-compose.yml
@@ -9,3 +9,13 @@ services:
       - .env
     volumes:
       - ./.nodes:/root/.nodes
+  anvil:
+    container_name: anvil
+    platform: linux/amd64
+    build:
+      context: ./docker/ethereum
+      dockerfile: Dockerfile
+    env_file:
+      - .env
+    expose:
+      - 8545

--- a/docker/dev-desktop/docker/eigenlayer/start.sh
+++ b/docker/dev-desktop/docker/eigenlayer/start.sh
@@ -40,8 +40,9 @@ wait_for_ethereum() {
     echo "Waiting for Ethereum node to be ready..."
     while ! curl -s -X POST -H "Content-Type: application/json" \
                  --data '{"jsonrpc":"2.0","method":"net_version","params":[],"id":1}' \
-                 "$LOCAL_ETHEREUM_RPC_URL" > /dev/null
+                 "$LOCAL_ETHEREUM_RPC_URL"
     do
+        echo "Pinging $LOCAL_ETHEREUM_RPC_URL"
         sleep 1
     done
     echo "Ethereum node is ready!"
@@ -464,7 +465,7 @@ if [ "$DEPLOY_ENV" = "TESTNET" ]; then
         exit 1
     fi
 else
-    LOCAL_ETHEREUM_RPC_URL=http://host.docker.internal:8545
+    LOCAL_ETHEREUM_RPC_URL=${LOCAL_ETHEREUM_RPC_URL:-http://host.docker.internal:8545}
     wait_for_ethereum
     cast rpc anvil_setBalance $deployer_public_key 0x10000000000000000000 -r $LOCAL_ETHEREUM_RPC_URL > /dev/null 2>&1
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
Just making a PR for visibility.

Here are some changes I made so I could run the `docker compose up` command properly, and include the anvil part in the setup. Maybe useful for others. But mainly my learnings.

Some links to various setup scripts I am looking at:

* [start.sh](https://github.com/Lay3rLabs/WAVS/blob/895d111c05e6bb7d2aecfe8d9089501941e4c72c/docker/dev-desktop/docker/eigenlayer/start.sh#L494) starting at the main logic (which calls high level functions)
* [Rust deploy_service_manager](https://github.com/Lay3rLabs/WAVS/blob/895d111c05e6bb7d2aecfe8d9089501941e4c72c/packages/utils/src/avs_client/full.rs#L156) - seems to have a different, simpler flow to set the operator set / stake registry contract than the code in start.sh, making me think these are some older version of the contracts.
* [Rust eigenlayer core deploy](https://github.com/Lay3rLabs/WAVS/blob/895d111c05e6bb7d2aecfe8d9089501941e4c72c/packages/utils/src/eigen_client/avs_deploy.rs#L28) - this deploys some old version of the eigenlayer core contracts taken from hello world avs
* Eigenlayer solidity deploy core script - [v1.1.1](https://github.com/Layr-Labs/eigenlayer-contracts/blob/v1.1.1/script/deploy/local/deploy_from_scratch.slashing.s.sol) and [v1.3.0](https://github.com/Layr-Labs/eigenlayer-contracts/blob/v1.3.0/script/deploy/local/deploy_from_scratch.slashing.s.sol)
  * Unclear how well these work, but seem to be used in their CI.
  * Called in their [task setup test](https://github.com/Layr-Labs/eigenlayer-contracts/blob/v1.3.0/script/tasks/run.sh#L19)

These all do similar things. Cross-referencing helps me find the common patterns vs implementation details
 