### PR TITLE
Add support for cli service command json output

### DIFF
--- a/packages/cli/src/args.rs
+++ b/packages/cli/src/args.rs
@@ -480,6 +480,11 @@ pub struct CliArgs {
     #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quiet_results: Option<bool>,
+
+    /// Returns result as JSON
+    #[arg(long)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub json: Option<bool>,
 }
 
 impl CliEnvExt for CliArgs {

--- a/packages/cli/src/context.rs
+++ b/packages/cli/src/context.rs
@@ -23,6 +23,7 @@ pub struct CliContext {
     pub config: Config,
     pub save_deployment: bool,
     pub quiet_results: bool,
+    pub json: bool,
     _clients: HashMap<ChainName, AnyClient>,
 }
 
@@ -40,7 +41,7 @@ impl CliContext {
         let mut chains: HashSet<ChainName> = HashSet::new();
 
         let deployment = match deployment {
-            None => Deployment::load(&config)?,
+            None => Deployment::load(&config, command.args().json.unwrap_or_default())?,
             Some(deployment) => deployment,
         };
 
@@ -112,8 +113,9 @@ impl CliContext {
         config: Config,
         deployment: Option<Deployment>,
     ) -> Result<Self> {
+        let json = args.json.unwrap_or_default();
         let deployment = match deployment {
-            None => Deployment::load(&config)?,
+            None => Deployment::load(&config, json)?,
             Some(deployment) => deployment,
         };
 
@@ -146,6 +148,7 @@ impl CliContext {
             deployment: Mutex::new(deployment),
             save_deployment: args.save_deployment.unwrap_or(true),
             quiet_results: args.quiet_results.unwrap_or_default(),
+            json,
             _clients: clients,
         })
     }

--- a/packages/cli/src/deploy.rs
+++ b/packages/cli/src/deploy.rs
@@ -20,12 +20,17 @@ pub struct Deployment {
 }
 
 impl Deployment {
-    pub fn load(config: &Config) -> Result<Self> {
+    pub fn load(config: &Config, json: bool) -> Result<Self> {
         let path = Self::path(config);
-        tracing::debug!("Loading deployment from {}", path.display());
+
+        if !json {
+            tracing::debug!("Loading deployment from {}", path.display());
+        }
 
         if !path.exists() {
-            tracing::warn!("No deployment file found at {:?}, using default", path);
+            if !json {
+                tracing::warn!("No deployment file found at {:?}, using default", path);
+            }
             return Ok(Self::default());
         }
 

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -160,6 +160,8 @@ async fn main() {
             command,
             file,
             args: _,
-        } => handle_service_command(&ctx, file, command).await.unwrap(),
+        } => handle_service_command(&ctx, file, ctx.json, command)
+            .await
+            .unwrap(),
     }
 }


### PR DESCRIPTION
closes #470 

Adds `--json` to CliArgs which prints the service json after manipulation
This is needed in CliArgs to silence tracing outside of the cli service scope: 
```
DEBUG Loading deployment from /var/wavs-cli/deployments.json
WARN No deployment file found at "/var/wavs-cli/deployments.json", using default
```

Example command:
`cargo run service --json true init --name test | jq .id`