### PR TITLE
feat: use private key if 'mnemonic' is set to 0x private key

### DIFF
--- a/packages/utils/src/eth_client.rs
+++ b/packages/utils/src/eth_client.rs
@@ -132,8 +132,8 @@ impl EthClientBuilder {
             .take()
             .ok_or(EthClientError::MissingMnemonic)?;
 
-        let signer: LocalSigner<SigningKey> = if mnemonic.starts_with("0x") {
-            let private_key = hex::decode(&mnemonic[2..])?;
+        let signer: LocalSigner<SigningKey> = if let Some(stripped) = mnemonic.strip_prefix("0x") {
+            let private_key = hex::decode(stripped)?;
             let secret_key = SecretKey::from_slice(&private_key)?;
             LocalSigner::from_signing_key(secret_key.into())
         } else {


### PR DESCRIPTION
## Summary

title

Mnemonics are nice but private keys are used more in Ethereum. We should support both in 1 input for users. 'Mnemonic' is likely not the best name input anymore.

This is required for the new wavs-middleware work (so we can use the deployer). Also just nice in general for any operator who wishes to use

Tested in the template and confirmed the address lines up with the expected account

```
WAVS_SUBMISSION_MNEMONIC="0x6ec2e96cc296808313fb364390cd4477722cb326a6a2a9ddd4e3760a0167f503"
WAVS_CLI_ETH_MNEMONIC="0x6ec2e96cc296808313fb364390cd4477722cb326a6a2a9ddd4e3760a0167f503"
WAVS_AGGREGATOR_MNEMONIC="0x6ec2e96cc296808313fb364390cd4477722cb326a6a2a9ddd4e3760a0167f503"
```