### PR TITLE
Refactor eth_mnemonic to eth_credential

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ WAVS_COSMOS_SUBMISSION_MNEMONIC="test test test test test test test test test te
 # CLI
 # WAVS_CLI_DATA=~/wavs/cli
 WAVS_CLI_COSMOS_MNEMONIC="test test test test test test test test test test test junk"
-WAVS_CLI_ETH_MNEMONIC="test test test test test test test test test test test junk"
+WAVS_CLI_ETH_CREDENTIAL="test test test test test test test test test test test junk"
 WAVS_CLI_LOG_LEVEL="info, wavs_cli=debug"
 
 # Aggregator

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -50,7 +50,7 @@ jobs:
         run: echo "WAVS_SUBMISSION_MNEMONIC=\"test test test test test test test test test test test junk\"" >> $GITHUB_ENV
 
       - name: Set env
-        run: echo "WAVS_CLI_ETH_MNEMONIC=\"test test test test test test test test test test test junk\"" >> $GITHUB_ENV
+        run: echo "WAVS_CLI_ETH_CREDENTIAL=\"test test test test test test test test test test test junk\"" >> $GITHUB_ENV
 
       - name: Set env
         run: echo "WAVS_AGGREGATOR_MNEMONIC=\"test test test test test test test test test test test junk\"" >> $GITHUB_ENV

--- a/packages/cli/src/args.rs
+++ b/packages/cli/src/args.rs
@@ -343,10 +343,11 @@ pub struct CliArgs {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<PathBuf>,
 
-    /// eth mnemonic (usually leave this as None and override in env)
+    /// Ethereum credential for signing transactions (can be a mnemonic or private key)
+    /// Usually leave this as None and override in env
     #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub eth_mnemonic: Option<String>,
+    pub eth_credential: Option<String>,
 
     /// cosmos mnemonic (usually leave this as None and override in env)
     #[arg(long)]

--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -26,8 +26,8 @@ pub struct Config {
     /// The mnemonic to use for submitting transactions on cosmos chains (usually None, set via env var)
     pub cosmos_mnemonic: Option<String>,
 
-    /// The mnemonic to use for submitting transactions on ethereum chains (usually None, set via env var)
-    pub eth_mnemonic: Option<String>,
+    /// The credential to use for submitting transactions on ethereum chains (mnemonic or private key)
+    pub eth_credential: Option<String>,
 
     pub registry_domain: Option<String>,
 }
@@ -57,7 +57,7 @@ impl Default for Config {
                 eth: BTreeMap::new(),
             },
             cosmos_mnemonic: None,
-            eth_mnemonic: None,
+            eth_credential: None,
             registry_domain: None,
         }
     }

--- a/packages/cli/src/context.rs
+++ b/packages/cli/src/context.rs
@@ -64,7 +64,7 @@ impl CliContext {
             .clone();
 
         let client_config =
-            chain_config.to_client_config(None, self.config.eth_mnemonic.clone(), None);
+            chain_config.to_client_config(None, self.config.eth_credential.clone(), None);
 
         let eth_client = EthClientBuilder::new(client_config).build_signing().await?;
 

--- a/packages/layer-tests/src/e2e/clients.rs
+++ b/packages/layer-tests/src/e2e/clients.rs
@@ -53,7 +53,7 @@ impl Clients {
             for (chain_name, chain_config) in &configs.chains.eth {
                 let client = EthClientBuilder::new(chain_config.to_client_config(
                     None,
-                    cli_ctx.config.eth_mnemonic.clone(),
+                    cli_ctx.config.eth_credential.clone(),
                     Some(EthClientTransport::Http),
                 ))
                 .build_signing()

--- a/packages/layer-tests/src/e2e/config.rs
+++ b/packages/layer-tests/src/e2e/config.rs
@@ -217,7 +217,7 @@ impl From<TestConfig> for Configs {
 
         cli_config.chains = chain_configs.clone();
         // some random mnemonic
-        cli_config.eth_mnemonic = Some(mnemonics.cli.clone());
+        cli_config.eth_credential = Some(mnemonics.cli.clone());
 
         // Sanity check
 

--- a/packages/utils/src/config.rs
+++ b/packages/utils/src/config.rs
@@ -351,20 +351,20 @@ impl EthereumChainConfig {
     pub fn to_client_config(
         &self,
         hd_index: Option<u32>,
-        mnemonic: Option<String>,
+        credential: Option<String>,
         transport: Option<EthClientTransport>,
     ) -> EthClientConfig {
         EthClientConfig {
             ws_endpoint: self.ws_endpoint.clone(),
             http_endpoint: self.http_endpoint.clone(),
             // if we are building a signing client, default to http transport
-            transport: match (transport, mnemonic.is_some()) {
+            transport: match (transport, credential.is_some()) {
                 (Some(transport), _) => Some(transport),
                 (None, true) => Some(EthClientTransport::Http),
                 _ => None,
             },
             hd_index,
-            mnemonic,
+            credential,
             gas_estimate_multiplier: None,
         }
     }

--- a/packages/utils/src/eth_client.rs
+++ b/packages/utils/src/eth_client.rs
@@ -71,7 +71,7 @@ impl EthSigningClient {
 pub struct EthClientConfig {
     pub ws_endpoint: Option<String>,
     pub http_endpoint: Option<String>,
-    pub mnemonic: Option<String>,
+    pub credential: Option<String>,
     pub hd_index: Option<u32>,
     /// Preferred transport
     pub transport: Option<EthClientTransport>,
@@ -135,7 +135,7 @@ impl EthClientBuilder {
         }
         let mnemonic = self
             .config
-            .mnemonic
+            .credential
             .take()
             .ok_or(EthClientError::MissingMnemonic)?;
 

--- a/packages/utils/tests/eth_client.rs
+++ b/packages/utils/tests/eth_client.rs
@@ -45,7 +45,7 @@ async fn client_sign_message() {
     let config = EthClientConfig {
         ws_endpoint: Some(anvil.ws_endpoint().to_string()),
         http_endpoint: Some(anvil.endpoint().to_string()),
-        mnemonic: Some(
+        credential: Some(
             "work man father plunge mystery proud hollow address reunion sauce theory bonus"
                 .to_string(),
         ),


### PR DESCRIPTION
closes #530 

Improves naming of CliArg's eth_mnemonic to signal support for mnemonics or PK.
Internally, we still use mnemonics and keep a lot of the same naming.

Open for suggestions though