### PR TITLE
Remove hd_index > 0 check during signer creation

### DIFF
--- a/packages/utils/src/eth_client/signing.rs
+++ b/packages/utils/src/eth_client/signing.rs
@@ -13,11 +13,6 @@ pub fn make_signer(credentials: &str, hd_index: Option<u32>) -> super::Result<Pr
 
     match credentials.strip_prefix("0x") {
         Some(stripped) => {
-            // if the string begins with `0x`, it is a private key
-            // and so we can't derive additional keys from it
-            if hd_index > 0 {
-                return Err(EthClientError::DerivationWithPrivateKey.into());
-            }
             let private_key = const_hex::decode(stripped)?;
             let secret_key = SecretKey::from_slice(&private_key)?;
             Ok(PrivateKeySigner::from_signing_key(secret_key.into()))


### PR DESCRIPTION
When using a private key directly, `hd_index` should not matter because private keys are standalone and cannot be derived further.