### PR TITLE
trigger manager error handling

### DIFF
--- a/packages/wavs/src/apis/trigger.rs
+++ b/packages/wavs/src/apis/trigger.rs
@@ -32,8 +32,8 @@ pub trait TriggerManager: Send + Sync {
 pub enum TriggerError {
     #[error("climb: {0}")]
     Climb(anyhow::Error),
-    #[error("EvmClient: {0}")]
-    EvmClient(#[from] EvmClientError),
+    #[error("EvmClient (chain {0}): {1}")]
+    EvmClient(ChainName, EvmClientError),
     #[error("Evm subscription: {0}")]
     EvmSubscription(anyhow::Error),
     #[error("parse avs payload: {0}")]


### PR DESCRIPTION
* closes #609 

Technically, #608 sorta fixes this in a different way, but we should still handle errors here and it's a bugfix even if we _also_ error out earlier due to health checks ;)