### PR TITLE
Improve cli json output

### DIFF
--- a/packages/cli/src/command/service.rs
+++ b/packages/cli/src/command/service.rs
@@ -157,7 +157,7 @@ pub async fn handle_service_command(
                     n_blocks,
                 } => {
                     let result = set_block_interval_trigger(&file, id, chain_name, n_blocks)?;
-                    display_result(ctx, result, &file, json)?;
+                    display_result(ctx, result, json)?;
                 }
                 TriggerCommand::SetCron {
                     schedule,
@@ -165,7 +165,7 @@ pub async fn handle_service_command(
                     end_time,
                 } => {
                     let result = set_cron_trigger(&file, id, schedule, start_time, end_time)?;
-                    display_result(ctx, result, &file, json)?;
+                    display_result(ctx, result, json)?;
                 }
             },
         },


### PR DESCRIPTION
closes #618 

This outputs the serialized action result instead of the full service json. If we want to simplify any of the outputs even more, we can just implement a custom serialize. tbd https://github.com/Lay3rLabs/WAVS/issues/618#issuecomment-2868056117