### PR TITLE
remove `key` from `SigningKeyResponse`

### DIFF
--- a/packages/types/src/http.rs
+++ b/packages/types/src/http.rs
@@ -13,8 +13,6 @@ use utoipa::ToSchema;
 #[serde(rename_all = "snake_case")]
 pub enum SigningKeyResponse {
     Secp256k1 {
-        /// from alloy's SigningKey.to_bytes()
-        key: Vec<u8>,
         /// The derivation index used to create this key from the mnemonic
         hd_index: u32,
     },

--- a/packages/wavs/src/submission/core.rs
+++ b/packages/wavs/src/submission/core.rs
@@ -321,13 +321,15 @@ impl Submission for CoreSubmission {
             .unwrap()
             .get(&service_id)
             .ok_or(SubmissionError::MissingMnemonic)
-            .map(|SignerInfo { signer, hd_index }| {
-                let key = signer.credential().to_bytes().to_vec();
-
-                SigningKeyResponse::Secp256k1 {
-                    key,
-                    hd_index: *hd_index,
-                }
-            })
+            .map(
+                |SignerInfo {
+                     signer: _,
+                     hd_index,
+                 }| {
+                    SigningKeyResponse::Secp256k1 {
+                        hd_index: *hd_index,
+                    }
+                },
+            )
     }
 }


### PR DESCRIPTION
closes #663

## Summary

Now just hd_index, no private key shown

![image](https://github.com/user-attachments/assets/cbb9c585-5503-4098-b02c-fbbf2f87bc2e)
