### PR TITLE
Install cargo-component in wasm publish ci

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,6 +100,9 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@v2
 
+      - name: Install cargo-component
+        run: cargo install cargo-component
+
       - name: Install wkg
         run: cargo install wkg
 


### PR DESCRIPTION
Fixes this error https://github.com/Lay3rLabs/WAVS/actions/runs/15352008380/job/43202297575

Components were published manually running `just wasi-publish` for the v0.4.0-rc tag