### PR TITLE
Enforce ordering in e2e tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4654,6 +4654,7 @@ dependencies = [
  "layer-climb",
  "layer-climb-cli",
  "opentelemetry",
+ "ordermap",
  "regex",
  "reqwest",
  "serde",
@@ -5455,6 +5456,15 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "ordermap"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d6bff06e4a5dc6416bead102d3e63c480dd852ffbb278bf8cfeb4966b329609"
+dependencies = [
+ "indexmap 2.10.0",
 ]
 
 [[package]]

--- a/packages/layer-tests/Cargo.toml
+++ b/packages/layer-tests/Cargo.toml
@@ -45,3 +45,4 @@ deadpool = "0.12.2"
 regex = "1.11.1"
 reqwest = { workspace = true }
 dashmap = { workspace = true }
+ordermap = "0.5.8"

--- a/packages/layer-tests/src/e2e/runner.rs
+++ b/packages/layer-tests/src/e2e/runner.rs
@@ -3,9 +3,10 @@
 use alloy_provider::Provider;
 use anyhow::{anyhow, Context};
 use futures::{stream::FuturesUnordered, StreamExt};
+use ordermap::OrderMap;
 use std::collections::HashSet;
+use std::sync::Arc;
 use std::time::Instant;
-use std::{collections::HashMap, sync::Arc};
 use wavs_types::{EvmContractSubmission, Submit, Trigger, Workflow, WorkflowID};
 
 use crate::e2e::helpers::change_service_for_test;
@@ -127,7 +128,7 @@ async fn run_test(
     }
 
     // Group workflows by trigger to handle multi-triggers
-    let mut trigger_groups: HashMap<&Trigger, Vec<(&WorkflowID, &Workflow)>> = HashMap::new();
+    let mut trigger_groups: OrderMap<&Trigger, Vec<(&WorkflowID, &Workflow)>> = OrderMap::new();
 
     for (workflow_id, workflow) in service.workflows.iter() {
         trigger_groups


### PR DESCRIPTION
closes #758 

Preference of ordermap over indexmap:

> Since its reintroduction in 0.5, ordermap has also used its entry order for PartialEq and Eq, whereas indexmap considers the same entries in any order to be equal for drop-in compatibility with HashMap semantics. Using the order is faster, and also allows ordermap to implement PartialOrd, Ord, and Hash.