### PR TITLE
fix(0.5.x): validate cli

### DIFF
--- a/packages/cli/src/command/service.rs
+++ b/packages/cli/src/command/service.rs
@@ -1050,7 +1050,7 @@ pub async fn validate_service(
                             }
                         }
                         Some(AnyChainConfig::Evm(_)) => {
-                            let evm_client = ctx.new_evm_client(chain_name).await?;
+                            let evm_client = ctx.new_evm_client_read_only(chain_name).await?;
                             let block_height = evm_client.provider.get_block_number().await?;
                             if let Err(err) = validate_block_interval_config_on_chain(
                                 *start_block,
@@ -1117,7 +1117,7 @@ pub async fn validate_service(
                     }
                 }
                 ChainType::EVM => {
-                    if let Ok(client) = ctx.new_evm_client(chain_name).await {
+                    if let Ok(client) = ctx.new_evm_client_read_only(chain_name).await {
                         evm_providers.insert(chain_name.clone(), client.provider.root().clone());
                     }
                 }

--- a/packages/cli/src/context.rs
+++ b/packages/cli/src/context.rs
@@ -75,6 +75,31 @@ impl CliContext {
         Ok(evm_client)
     }
 
+    /// Creates an EVM client for read-only operations (validation, queries)
+    /// Uses a dummy credential if none is configured
+    pub(crate) async fn new_evm_client_read_only(
+        &self,
+        chain_name: &ChainName,
+    ) -> Result<EvmSigningClient> {
+        let chain_config = self
+            .config
+            .chains
+            .evm
+            .get(chain_name)
+            .context(format!("chain {chain_name} not found"))?
+            .clone();
+
+        // Use actual credential if available, otherwise use a dummy one for read-only operations
+        let credential = self.config.evm_credential.clone().unwrap_or_else(|| {
+            "0x0000000000000000000000000000000000000000000000000000000000000001".to_string()
+        });
+
+        let client_config = chain_config.signing_client_config(credential)?;
+        let evm_client = EvmSigningClient::new(client_config).await?;
+
+        Ok(evm_client)
+    }
+
     pub async fn new_cosmos_client(&self, chain_name: &ChainName) -> Result<SigningClient> {
         let chain_config = self
             .config


### PR DESCRIPTION
## Summary

backport patch (caught upgrading bridge to 0.5.3) from https://github.com/Lay3rLabs/WAVS/pull/797

Without this patch
<img width="688" height="164" alt="image" src="https://github.com/user-attachments/assets/ae070102-193e-4b84-b642-3dbb9fb969a4" />
