### PR TITLE
service docs

### DIFF
--- a/packages/types/src/service.rs
+++ b/packages/types/src/service.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::{hex, LogData};
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::num::{NonZeroU32, NonZeroU64};
 use std::str::FromStr;
 use utoipa::ToSchema;


### PR DESCRIPTION
* closes #708 

As [noted in the issue](https://github.com/Lay3rLabs/WAVS/issues/708#issuecomment-3280349992), we can't validate the service from WAVS since the service handler is only known after executing the aggregator component.

So this PR just adds a bit of documentation