### PR TITLE
[dnm] filtered stream and catchup stream POC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8191,6 +8191,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -9710,6 +9711,7 @@ dependencies = [
  "alloy-signer-local",
  "alloy-sol-types",
  "anyhow",
+ "async-stream",
  "axum",
  "axum-tracing-opentelemetry",
  "bimap",
@@ -9736,6 +9738,7 @@ dependencies = [
  "thiserror 2.0.16",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tower",
  "tower-http",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,9 +81,11 @@ shellexpand = "3.1.1"
 tokio = { version = "1.46.1", features = ["full"] }
 tokio-stream = { version = "0.1" }
 futures = "0.3.31"
+tokio-util = { version = "0.7.12", features = ["rt"] }
 ctrlc = "3.4.7"
 temp-env = { version = "0.3.6", features = ["async_closure"] }
 async-trait = "0.1.88"
+async-stream = "0.3"
 
 # collections
 dashmap = "6.1.0"

--- a/packages/wavs/Cargo.toml
+++ b/packages/wavs/Cargo.toml
@@ -21,6 +21,7 @@ clap = { workspace = true }
 anyhow = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
+tokio-util = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
@@ -37,6 +38,7 @@ layer-climb = { workspace = true }
 ctrlc = { workspace = true }
 tempfile = { workspace = true }
 futures = { workspace = true }
+async-stream = { workspace = true }
 cosmwasm-std = { workspace = true }
 reqwest = { workspace = true }
 url = { workspace = true }

--- a/packages/wavs/src/subsystems/trigger/recovery.rs
+++ b/packages/wavs/src/subsystems/trigger/recovery.rs
@@ -1,0 +1,158 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use wavs_types::ChainKey;
+
+#[derive(Debug, Clone, Default)]
+pub struct ChainRecoveryState {
+    pub last_processed_block: Option<u64>,
+    pub last_error_time: Option<std::time::Instant>,
+    pub is_in_recovery: bool,
+    pub recovery_block: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RecoveryManager {
+    states: Arc<RwLock<HashMap<ChainKey, ChainRecoveryState>>>,
+    max_recovery_delay: std::time::Duration,
+}
+
+impl RecoveryManager {
+    pub fn new(max_recovery_delay: std::time::Duration) -> Self {
+        Self {
+            states: Arc::new(RwLock::new(HashMap::new())),
+            max_recovery_delay,
+        }
+    }
+
+    /// Record that a block was successfully processed
+    pub async fn record_successful_block(&self, chain: &ChainKey, block_number: u64) {
+        let mut states = self.states.write().await;
+        let state = states.entry(chain.clone()).or_default();
+        state.last_processed_block = Some(block_number);
+        state.last_error_time = None;
+        state.is_in_recovery = false;
+        state.recovery_block = None;
+    }
+
+    /// Record that an error occurred while processing a stream
+    pub async fn record_stream_error(&self, chain: &ChainKey) {
+        let mut states = self.states.write().await;
+        let state = states.entry(chain.clone()).or_default();
+        state.last_error_time = Some(std::time::Instant::now());
+
+        // Check if we need to start recovery mode
+        if let Some(last_processed) = state.last_processed_block {
+            let should_start_recovery = state.last_error_time.map_or(false, |error_time| {
+                error_time.elapsed() > self.max_recovery_delay
+            });
+
+            if should_start_recovery && !state.is_in_recovery {
+                state.is_in_recovery = true;
+                state.recovery_block = Some(last_processed + 1);
+            }
+        }
+    }
+
+    /// Check if a chain needs recovery
+    pub async fn needs_recovery(&self, chain: &ChainKey) -> Option<u64> {
+        let states = self.states.read().await;
+        if let Some(state) = states.get(chain) {
+            if state.is_in_recovery {
+                return state.recovery_block;
+            }
+        }
+        None
+    }
+
+    /// Start recovery mode from a specific block
+    pub async fn start_recovery(&self, chain: &ChainKey, from_block: u64) -> bool {
+        let mut states = self.states.write().await;
+        if let Some(state) = states.get_mut(chain) {
+            state.is_in_recovery = true;
+            state.recovery_block = Some(from_block);
+            return true;
+        }
+        false
+    }
+
+    /// End recovery mode
+    pub async fn end_recovery(&self, chain: &ChainKey) {
+        let mut states = self.states.write().await;
+        if let Some(state) = states.get_mut(chain) {
+            state.is_in_recovery = false;
+            state.recovery_block = None;
+        }
+    }
+
+    /// Get the current recovery state for a chain
+    pub async fn get_state(&self, chain: &ChainKey) -> Option<ChainRecoveryState> {
+        let states = self.states.read().await;
+        states.get(chain).cloned()
+    }
+
+    /// Get all chains that are in recovery mode
+    pub async fn get_all_recovery_chains(&self) -> Vec<ChainKey> {
+        let states = self.states.read().await;
+        states
+            .iter()
+            .filter(|(_, state)| state.is_in_recovery)
+            .map(|(chain, _)| chain.clone())
+            .collect()
+    }
+
+    /// Clean up old recovery states
+    pub async fn cleanup_old_states(&self, older_than: std::time::Duration) {
+        let mut states = self.states.write().await;
+        states.retain(|_, state| {
+            if let Some(error_time) = state.last_error_time {
+                error_time.elapsed() < older_than
+            } else {
+                true
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn test_recovery_manager() {
+        let manager = RecoveryManager::new(Duration::from_secs(10));
+        let chain: ChainKey = "evm:1".parse().unwrap();
+
+        // Initially no recovery needed
+        assert!(manager.needs_recovery(&chain).await.is_none());
+
+        // Record a successful block
+        manager.record_successful_block(&chain, 100).await;
+        assert!(manager.needs_recovery(&chain).await.is_none());
+
+        // Record an error
+        manager.record_stream_error(&chain).await;
+        assert!(manager.needs_recovery(&chain).await.is_none());
+
+        // Wait for recovery delay
+        tokio::time::sleep(Duration::from_secs(11)).await;
+
+        // Now recovery should be needed
+        assert_eq!(manager.needs_recovery(&chain).await, Some(101));
+    }
+
+    #[tokio::test]
+    async fn test_start_recovery() {
+        let manager = RecoveryManager::new(Duration::from_secs(10));
+        let chain: ChainKey = "evm:1".parse().unwrap();
+
+        // Start recovery directly
+        assert!(manager.start_recovery(&chain, 50).await);
+        assert_eq!(manager.needs_recovery(&chain).await, Some(50));
+
+        // End recovery
+        manager.end_recovery(&chain).await;
+        assert!(manager.needs_recovery(&chain).await.is_none());
+    }
+}

--- a/packages/wavs/src/subsystems/trigger/streams.rs
+++ b/packages/wavs/src/subsystems/trigger/streams.rs
@@ -1,3 +1,4 @@
+pub mod catchup;
 pub mod cosmos_stream;
 pub mod cron_stream;
 pub mod evm_stream;

--- a/packages/wavs/src/subsystems/trigger/streams/catchup.rs
+++ b/packages/wavs/src/subsystems/trigger/streams/catchup.rs
@@ -1,0 +1,92 @@
+use alloy_provider::Provider;
+use alloy_rpc_types_eth::BlockNumberOrTag;
+use alloy_rpc_types_eth::Filter as EthFilter;
+use futures::Stream;
+use std::pin::Pin;
+use utils::{evm_client::EvmQueryClient, telemetry::TriggerMetrics};
+use wavs_types::ChainKey;
+
+use crate::subsystems::trigger::error::TriggerError;
+use crate::subsystems::trigger::recovery::RecoveryManager;
+use crate::subsystems::trigger::streams::StreamTriggers;
+
+/// Start a ranged EVM event backfill stream using a provided filter from from_block to snapshot latest.
+pub async fn start_event_backfill_stream(
+    chain: ChainKey,
+    client: EvmQueryClient,
+    recovery_manager: std::sync::Arc<RecoveryManager>,
+    filter: EthFilter,
+    from_block: u64,
+    _metrics: TriggerMetrics,
+) -> Result<Pin<Box<dyn Stream<Item = Result<StreamTriggers, TriggerError>> + Send>>, TriggerError>
+{
+    // Snapshot latest at start
+    let latest_snapshot = match client.provider.get_block_number().await {
+        Ok(latest) => latest,
+        Err(e) => {
+            tracing::error!("Failed to get latest block for chain {}: {:?}", chain, e);
+            return Err(TriggerError::EvmSubscription(e.into()));
+        }
+    };
+
+    let range_start = from_block;
+    let range_end = latest_snapshot;
+    let chain_clone = chain.clone();
+    let recovery = recovery_manager.clone();
+
+    // Chunk size to avoid provider limits
+    const CHUNK: u64 = 2_000;
+
+    Ok(Box::pin(async_stream::try_stream! {
+        let mut start = range_start;
+        while start <= range_end {
+            // Stop if recovery ended
+            if let Some(state) = recovery.get_state(&chain_clone).await {
+                if !state.is_in_recovery { break; }
+            }
+
+            let end = std::cmp::min(start + CHUNK - 1, range_end);
+            let mut f = filter.clone();
+            f = f.from_block(BlockNumberOrTag::Number(start.into())).to_block(BlockNumberOrTag::Number(end.into()));
+
+            tracing::info!("Backfilling logs for chain {} blocks [{}..={}]", chain_clone, start, end);
+            match client.provider.get_logs(&f).await {
+                Ok(logs) => {
+                    for log in logs {
+                        if log.removed { continue; }
+                        let block_timestamp = log.block_timestamp;
+                        match (log.block_hash, log.transaction_index, log.block_number, log.transaction_hash, log.log_index) {
+                            (Some(block_hash), Some(tx_index), Some(block_number), Some(tx_hash), Some(log_index)) => {
+                                // Surface as Evm trigger
+                                yield StreamTriggers::Evm {
+                                    chain: chain_clone.clone(),
+                                    block_number,
+                                    tx_hash,
+                                    log_index,
+                                    log: Box::new(log),
+                                    block_hash,
+                                    block_timestamp,
+                                    tx_index,
+                                };
+
+                                // Record block processed for recovery
+                                recovery.record_successful_block(&chain_clone, block_number).await;
+                            }
+                            _ => {
+                                tracing::debug!("Dropping incomplete EVM log during backfill");
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("get_logs backfill error on chain {} for range [{}..={}]: {:?}", chain_clone, start, end, e);
+                    // small backoff to avoid hot loop
+                    tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
+                }
+            }
+
+            if end == u64::MAX { break; }
+            start = end.saturating_add(1);
+        }
+    }))
+}

--- a/packages/wavs/src/subsystems/trigger/streams/evm_stream.rs
+++ b/packages/wavs/src/subsystems/trigger/streams/evm_stream.rs
@@ -2,6 +2,8 @@ use alloy_provider::Provider;
 use alloy_rpc_types_eth::Filter;
 use futures::{Stream, StreamExt};
 use std::pin::Pin;
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
 use utils::{evm_client::EvmQueryClient, telemetry::TriggerMetrics};
 use wavs_types::ChainKey;
 
@@ -9,65 +11,86 @@ use crate::subsystems::trigger::error::TriggerError;
 
 use super::StreamTriggers;
 
-pub async fn start_evm_event_stream(
+/// Start a resilient EVM event stream that auto-reconnects and can accept a narrowed filter.
+pub async fn start_evm_stream(
     query_client: EvmQueryClient,
     chain: ChainKey,
+    filter: Filter,
     _metrics: TriggerMetrics,
+    cancel: CancellationToken,
 ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamTriggers, TriggerError>> + Send>>, TriggerError>
 {
-    let filter = Filter::new();
+    let provider = query_client.provider.clone();
+    let chain_cloned = chain.clone();
 
-    let stream = query_client
-        .provider
-        .subscribe_logs(&filter)
-        .await
-        .map_err(|e| TriggerError::EvmSubscription(e.into()))?
-        .into_stream();
-
-    let chain = chain.clone();
-
-    let event_stream = Box::pin(stream.filter_map(move |log| {
-        let chain = chain.clone();
-        async move {
-            if log.removed {
-                tracing::warn!("Reorg removed log: {:?}", log);
-                return None;
-            }
-
-            let block_timestamp = log.block_timestamp;
-
-            match (
-                log.block_hash,
-                log.transaction_index,
-                log.block_number,
-                log.transaction_hash,
-                log.log_index,
-            ) {
-                (
-                    Some(block_hash),
-                    Some(tx_index),
-                    Some(block_number),
-                    Some(tx_hash),
-                    Some(log_index),
-                ) => Some(Ok(StreamTriggers::Evm {
-                    chain: chain.clone(),
-                    block_number,
-                    tx_hash,
-                    log_index,
-                    log: Box::new(log),
-                    block_hash,
-                    block_timestamp,
-                    tx_index,
-                })),
-                _ => {
-                    tracing::warn!("Received incomplete EVM log: {:?}", log);
-                    None
+    let stream = async_stream::stream! {
+        let mut backoff_ms = 500u64;
+        loop {
+            tracing::info!(target: "wavs::evm_stream", chain = %chain_cloned, "Subscribing to logs with filter: {:?}", filter);
+            match provider.subscribe_logs(&filter).await {
+                Ok(sub) => {
+                    backoff_ms = 500; // reset backoff on success
+                    let mut inner = sub.into_stream();
+                    let mut should_exit = false;
+                    loop {
+                        tokio::select! {
+                            biased;
+                            // shutdown first
+                            _ = cancel.cancelled() => {
+                                tracing::info!("EVM log subscription received shutdown signal");
+                                should_exit = true;
+                                break;
+                            }
+                            maybe_log = inner.next() => {
+                                match maybe_log {
+                                    Some(log) => {
+                                        if log.removed { continue; }
+                                        let block_timestamp = log.block_timestamp;
+                                        match (log.block_hash, log.transaction_index, log.block_number, log.transaction_hash, log.log_index) {
+                                            (Some(block_hash), Some(tx_index), Some(block_number), Some(tx_hash), Some(log_index)) => {
+                                                yield Ok(StreamTriggers::Evm {
+                                                    chain: chain_cloned.clone(),
+                                                    block_number,
+                                                    tx_hash,
+                                                    log_index,
+                                                    log: Box::new(log),
+                                                    block_hash,
+                                                    block_timestamp,
+                                                    tx_index,
+                                                });
+                                            }
+                                            _ => {
+                                                tracing::debug!("Dropping incomplete EVM log: {:?}", log);
+                                            }
+                                        }
+                                    }
+                                    None => break,
+                                }
+                            }
+                        }
+                    }
+                    if should_exit {
+                        tracing::info!("EVM log subscription exiting after shutdown");
+                        break;
+                    } else {
+                        // EOF or subscription ended. Surface a soft error and retry.
+                        tracing::warn!("EVM log subscription ended; reconnecting...");
+                        yield Err(TriggerError::EvmSubscription(anyhow::anyhow!("log subscription ended")));
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("EVM subscribe_logs error: {:?}", e);
+                    yield Err(TriggerError::EvmSubscription(e.into()));
                 }
             }
-        }
-    }));
 
-    Ok(event_stream)
+            // Exponential backoff before resubscribing
+            tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
+            backoff_ms = (backoff_ms.saturating_mul(2)).min(10_000);
+        }
+    };
+
+    Ok(Box::pin(stream))
 }
 
 pub async fn start_evm_block_stream(
@@ -76,20 +99,32 @@ pub async fn start_evm_block_stream(
     _metrics: TriggerMetrics,
 ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamTriggers, TriggerError>> + Send>>, TriggerError>
 {
-    // Start the block stream (for block-based triggers)
-    let stream = query_client
-        .provider
-        .subscribe_blocks()
-        .await
-        .map_err(|e| TriggerError::EvmSubscription(e.into()))?
-        .into_stream();
+    let provider = query_client.provider.clone();
+    let chain_cloned = chain.clone();
 
-    let block_stream = Box::pin(stream.map(move |block| {
-        Ok(StreamTriggers::EvmBlock {
-            chain: chain.clone(),
-            block_height: block.number,
-        })
-    }));
+    let stream = async_stream::stream! {
+        let mut backoff_ms = 500u64;
+        loop {
+            match provider.subscribe_blocks().await {
+                Ok(sub) => {
+                    backoff_ms = 500;
+                    let mut inner = sub.into_stream();
+                    while let Some(block) = inner.next().await {
+                        yield Ok(StreamTriggers::EvmBlock { chain: chain_cloned.clone(), block_height: block.number });
+                    }
+                    tracing::warn!("EVM block subscription ended; reconnecting...");
+                    yield Err(TriggerError::EvmSubscription(anyhow::anyhow!("block subscription ended")));
+                }
+                Err(e) => {
+                    tracing::error!("EVM subscribe_blocks error: {:?}", e);
+                    yield Err(TriggerError::EvmSubscription(e.into()));
+                }
+            }
 
-    Ok(block_stream)
+            tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+            backoff_ms = (backoff_ms.saturating_mul(2)).min(10_000);
+        }
+    };
+
+    Ok(Box::pin(stream))
 }


### PR DESCRIPTION
dnm - needs more discussion, clean up (gpt'd a good portion), and test-cases 

The goal is to reduce information received from RPC providers (reducing credit usage) by filtering on exactly what's needed by the Service.json (all triggers + service manager change service). Also introduced are catch-up streams and resilient streams.

Another benefit of this is avoiding high memory consumption. ref #990 
Currently, our trigger manager immediately discards all logs without topic0. Otherwise, we're grabbing a read lock to check if the contract is in our trigger map for every log.