### PR TITLE
Fix publish npm CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,9 @@ env:
   CRATE_NAME: wavs-types
   CRATE_PATH: packages/types
 
+permissions:
+  id-token: write # Required for OIDC
+
 jobs:
   publish_crate:
     name: Verify and Publish Crate

--- a/packages/types/ts.rs
+++ b/packages/types/ts.rs
@@ -43,7 +43,7 @@ fn create_package_json(version: &str) -> String {
   "license": "GPL-3.0-or-later",
   "repository": {{
     "type": "git",
-    "url": "https://github.com/Lay3rLabs/WAVS.git",
+    "url": "git+https://github.com/Lay3rLabs/WAVS.git",
     "directory": "packages/types/bindings"
   }},
   "homepage": "https://github.com/Lay3rLabs/WAVS/tree/main/packages/types",


### PR DESCRIPTION
ref https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow

> The critical requirement is the id-token: write permission, which allows GitHub Actions to generate OIDC tokens.