### PR TITLE
Replace Mutex with RwLock in test registry

### DIFF
--- a/packages/layer-tests/src/e2e/test_registry.rs
+++ b/packages/layer-tests/src/e2e/test_registry.rs
@@ -27,7 +27,7 @@ use wavs_types::{ChainConfigs, ChainKey, Service, Trigger, WorkflowId};
 /// This map is used to ensure cosmos contracts only have their wasm uploaded once
 /// Key -> Cosmos Trigger Definition, Value -> Maybe Code Id
 pub type CosmosCodeMap =
-    Arc<DashMap<CosmosContractDefinition, Arc<tokio::sync::Mutex<Option<u64>>>>>;
+    Arc<DashMap<CosmosContractDefinition, Arc<tokio::sync::RwLock<Option<u64>>>>>;
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum CosmosContractDefinition {


### PR DESCRIPTION
I managed to hit a similar (not the same though) error locally - `Timeout when waiting for task to land`. I added several logs with timers for contract upload locks.
In the run that failed, I noticed (pasted below):

My idea to change it to RwLock:
- try reading lock first
- if contract is cached, return right away
- if it's a miss, make it into a write lock and upload

I'm still looking further into the main cause, I doubt thise ~3 seconds are going to lead to the timeout... 
```
...
[32m INFO[0m Deploying submit contract on chain evm:31337 with service manager: 0x8345AE1c2e64c0A2f69D79B346cBC236478C63F5
[32m INFO[0m Getting cosmos code ID for chain cosmos:wasmd-1
[32m INFO[0m Uploading cosmos wasm byte code (257281 bytes) to chain cosmos:wasmd-1
[32m INFO[0m Successfully uploaded WASM bytecode to chain cosmos:wasmd-1, code_id: 2 in 2.30748102s
[33m WARN[0m Lock acquisition took 2.310971461s for Submit(MockServiceHandler { chain: ChainKey { namespace: ChainKeyNamespace("cosmos"), id: ChainKeyId("wasmd-1") } })
[33m WARN[0m Lock acquisition took 2.321983169s for Submit(MockServiceHandler { chain: ChainKey { namespace: ChainKeyNamespace("cosmos"), id: ChainKeyId("wasmd-1") } })
[33m WARN[0m Lock acquisition took 2.33315184s for Submit(MockServiceHandler { chain: ChainKey { namespace: ChainKeyNamespace("cosmos"), id: ChainKeyId("wasmd-1") } })
[33m WARN[0m Lock acquisition took 2.344343553s for Submit(MockServiceHandler { chain: ChainKey { namespace: ChainKeyNamespace("cosmos"), id: ChainKeyId("wasmd-1") } })
[33m WARN[0m Lock acquisition took 2.355853355s for Submit(MockServiceHandler { chain: ChainKey { namespace: ChainKeyNamespace("cosmos"), id: ChainKeyId("wasmd-1") } })
[33m WARN[0m Lock acquisition took 2.369130856s for Submit(MockServiceHandler { chain: ChainKey { namespace: ChainKeyNamespace("cosmos"), id: ChainKeyId("wasmd-1") } })
...
[33m WARN[0m *************************************
[33m WARN[0m Starting test: evm_cosmos_query
[33m WARN[0m *************************************
[32m INFO[0m Successfully extracted 1 trigger IDs: [1]
[32m INFO[0m Starting workflow validation for 1 workflows
[32m INFO[0m Validating workflow: cosmos_query
[32m INFO[0m Processing trigger_id: 1 for workflow: cosmos_query
[32m INFO[0m Getting submit start block for workflow: cosmos_query
[32m INFO[0m Submit start block: 85
[32m INFO[0m Submission contract for workflow cosmos_query: 0xad7a5b84ba0e093f8c33f87edd5f35400343bebc
[32m INFO[0m Waiting for task to land (no re-org) for trigger_id: 1

thread '<unnamed>' panicked at /home/u/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-timer-3.0.3/src/native/delay.rs:112:21:
timer has gone away
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'e2e_tests' panicked at packages/layer-tests/src/e2e/runner.rs:232:14:
called `Result::unwrap()` on an `Err` value: evm_cosmos_query

Caused by:
    Timeout when waiting for task to land
```
