### PR TITLE
Improve aggregator error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,9 +1536,9 @@ checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
 
 [[package]]
 name = "bitcoin_hashes"
@@ -4949,9 +4949,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libdbus-sys"
@@ -8992,13 +8992,13 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
- "serde",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/packages/aggregator/src/http/handlers/packet.rs
+++ b/packages/aggregator/src/http/handlers/packet.rs
@@ -329,7 +329,7 @@ async fn process_action(
                                 }
                             }
                             Err(e) => {
-                                tracing::error!("Quorum validation failed: {:?}", e);
+                                tracing::error!("Service handler encountered an error: {:?}", e);
                                 Err(e)
                             }
                         }


### PR DESCRIPTION
Improve error returned by the aggregator in case of service handler internal failure (for example solidity call failing with no error).
In my case - solidity `abi_decode` call was failing silently (only 0x revert) and that was being printed with a confusing error "Quorum validation failed" which wasn't reflecting the actual situation.

```
2025-12-01T12:01:53.939945Z ERROR handle_packet{service.name=at-protocol-monitor service.manager=Evm { chain: ChainKey { namespace: ChainKeyNamespace("evm"), id: ChainKeyId("31337") }, address: 0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0 } workflow_id=at_protocol_poll event_id=9e086f46b7dd5c5c07c01038fb9c58ab3cbd58c1}:process_packet{service.name=at-protocol-monitor service.manager=Evm { chain: ChainKey { namespace: ChainKeyNamespace("evm"), id: ChainKeyId("31337") }, address: 0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0 } workflow_id=at_protocol_poll event_id=9e086f46b7dd5c5c07c01038fb9c58ab3cbd58c1}:run{signer=0x25c2ad30bad139529d23b6eb13098a51091e9654}: wavs_aggregator::http::handlers::packet: Quorum validation failed: EvmClient(TransactionWithoutReceipt(server returned an error response: error code 3: execution reverted, data: "0x"))

2025-12-01T12:01:53.940022Z ERROR handle_packet{service.name=at-protocol-monitor service.manager=Evm { chain: ChainKey { namespace: ChainKeyNamespace("evm"), id: ChainKeyId("31337") }, address: 0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0 } workflow_id=at_protocol_poll event_id=9e086f46b7dd5c5c07c01038fb9c58ab3cbd58c1}:process_packet{service.name=at-protocol-monitor service.manager=Evm { chain: ChainKey { namespace: ChainKeyNamespace("evm"), id: ChainKeyId("31337") }, address: 0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0 } workflow_id=at_protocol_poll event_id=9e086f46b7dd5c5c07c01038fb9c58ab3cbd58c1}:run{signer=0x25c2ad30bad139529d23b6eb13098a51091e9654}: wavs_aggregator::http::handlers::packet: Action 1 processing failed: EvmClient(TransactionWithoutReceipt(server returned an error response: error code 3: execution reverted, data: "0x"))
```