### PR TITLE
Track WIT deps

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -33,22 +33,6 @@ jobs:
         with:
           cache-on-failure: true
 
-      - name: Install just
-        uses: extractions/setup-just@v3
-
-      - name: Install wkg
-        run: cargo install wkg
-
-      - name: Configure wasm-pkg registry
-        run: |
-          mkdir -p ~/.config/wasm-pkg
-          cat > ~/.config/wasm-pkg/config.toml << 'EOF'
-          default_registry = "wa.dev"
-          EOF
-
-      - name: Fetch WIT dependencies
-        run: just wit-deps-fetch
-
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
@@ -79,22 +63,6 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-
-      - name: Install just
-        uses: extractions/setup-just@v3
-
-      - name: Install wkg
-        run: cargo install wkg
-
-      - name: Configure wasm-pkg registry
-        run: |
-          mkdir -p ~/.config/wasm-pkg
-          cat > ~/.config/wasm-pkg/config.toml << 'EOF'
-          default_registry = "wa.dev"
-          EOF
-
-      - name: Fetch WIT dependencies
-        run: just wit-deps-fetch
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -141,22 +109,6 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-
-      - name: Install just
-        uses: extractions/setup-just@v3
-
-      - name: Install wkg
-        run: cargo install wkg
-
-      - name: Configure wasm-pkg registry
-        run: |
-          mkdir -p ~/.config/wasm-pkg
-          cat > ~/.config/wasm-pkg/config.toml << 'EOF'
-          default_registry = "wa.dev"
-          EOF
-
-      - name: Fetch WIT dependencies
-        run: just wit-deps-fetch
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ deployments
 artifacts
 sdk/*.wasm
 wit-definitions/**/*.wasm
-wit-definitions/*/wit/deps
 temp_clone/
 **/.claude/settings.local.json
 packages/types/bindings

--- a/wit-definitions/aggregator/wit/deps/wavs-operator-2.7.0/package.wit
+++ b/wit-definitions/aggregator/wit/deps/wavs-operator-2.7.0/package.wit
@@ -1,0 +1,106 @@
+package wavs:operator@2.7.0;
+
+interface input {
+  use wavs:types/service@2.7.0.{service-id, workflow-id, trigger};
+  use wavs:types/events@2.7.0.{trigger-data};
+
+  record trigger-config {
+    service-id: service-id,
+    workflow-id: workflow-id,
+    trigger: trigger,
+  }
+
+  record trigger-action {
+    config: trigger-config,
+    data: trigger-data,
+  }
+}
+
+interface output {
+  use wavs:types/events@2.7.0.{event-id};
+
+  record wasm-response {
+    /// arbitrary payload returned from the component
+    /// and passed on to be signed by the operators
+    payload: list<u8>,
+    /// currently unused
+    ordering: option<u64>,
+    /// if not supplied, this will be `trigger-data`
+    /// if supplied, make sure this is unique for every response!
+    /// for example, using a "message id" from a third-party service
+    /// also, it MUST be supplied if multiple responses are returned
+    event-id-salt: option<list<u8>>,
+  }
+}
+
+world wavs-world {
+  import wavs:types/core@2.7.0;
+  import wavs:types/chain@2.7.0;
+  import wavs:types/service@2.7.0;
+  import wavs:types/events@2.7.0;
+  import input;
+  import output;
+  import wasi:io/poll@0.2.0;
+  import wasi:clocks/monotonic-clock@0.2.0;
+  import wasi:io/error@0.2.0;
+  import wasi:io/streams@0.2.0;
+  import wasi:http/types@0.2.0;
+  import wasi:http/outgoing-handler@0.2.0;
+  import host: interface {
+    use wavs:types/chain@2.7.0.{evm-chain-config, cosmos-chain-config};
+    use wavs:types/service@2.7.0.{service-and-workflow-id, workflow-and-workflow-id};
+    use wavs:types/core@2.7.0.{log-level};
+    use wavs:types/events@2.7.0.{event-id};
+
+    get-evm-chain-config: func(chain-key: string) -> option<evm-chain-config>;
+
+    get-cosmos-chain-config: func(chain-key: string) -> option<cosmos-chain-config>;
+
+    config-var: func(key: string) -> option<string>;
+
+    log: func(level: log-level, message: string);
+
+    /// gets the service and workflow id that called this component
+    get-service: func() -> service-and-workflow-id;
+
+    /// convenience function to get the workflow without having to walk service.workflows
+    get-workflow: func() -> workflow-and-workflow-id;
+
+    /// convenience function to get what the event id will be
+    /// typically only used for debugging or testing purposes
+    get-event-id: func(salt: option<list<u8>>) -> event-id;
+  }
+  import wasi:cli/environment@0.2.0;
+  import wasi:cli/exit@0.2.0;
+  import wasi:cli/stdin@0.2.0;
+  import wasi:cli/stdout@0.2.0;
+  import wasi:cli/stderr@0.2.0;
+  import wasi:cli/terminal-input@0.2.0;
+  import wasi:cli/terminal-output@0.2.0;
+  import wasi:cli/terminal-stdin@0.2.0;
+  import wasi:cli/terminal-stdout@0.2.0;
+  import wasi:cli/terminal-stderr@0.2.0;
+  import wasi:clocks/wall-clock@0.2.0;
+  import wasi:filesystem/types@0.2.0;
+  import wasi:filesystem/preopens@0.2.0;
+  import wasi:sockets/network@0.2.0;
+  import wasi:sockets/instance-network@0.2.0;
+  import wasi:sockets/udp@0.2.0;
+  import wasi:sockets/udp-create-socket@0.2.0;
+  import wasi:sockets/tcp@0.2.0;
+  import wasi:sockets/tcp-create-socket@0.2.0;
+  import wasi:sockets/ip-name-lookup@0.2.0;
+  import wasi:random/random@0.2.0;
+  import wasi:random/insecure@0.2.0;
+  import wasi:random/insecure-seed@0.2.0;
+  import wasi:keyvalue/store@0.2.0-draft2;
+  import wasi:keyvalue/atomics@0.2.0-draft2;
+  import wasi:keyvalue/batch@0.2.0-draft2;
+  @unstable(feature = tls)
+  import wasi:tls/types@0.2.0-draft;
+  use input.{trigger-action};
+  use output.{wasm-response};
+
+  /// if returning multiple responses, they must all have an event-id-salt
+  export run: func(trigger-action: trigger-action) -> result<list<wasm-response>, string>;
+}

--- a/wit-definitions/aggregator/wit/deps/wavs-types-2.7.0/package.wit
+++ b/wit-definitions/aggregator/wit/deps/wavs-types-2.7.0/package.wit
@@ -1,0 +1,330 @@
+package wavs:types@2.7.0;
+
+interface chain {
+  /// A string mostly following the caip-2 format of namespace:reference, e.g. "eip155:1" for Ethereum mainnet or "cosmos:cosmoshub-4" for Cosmos Hub
+  /// however, we allow up to 32 characters for the "namespace" part, and we call the "reference" part "chain-id" to confirm with popular usage
+  type chain-key = string;
+
+  type evm-tx-hash = list<u8>;
+
+  /// 32 bytes, a keccak hash of an RLP encoded signed transaction
+  type cosmos-tx-hash = string;
+
+  variant any-tx-hash {
+    evm(evm-tx-hash),
+    cosmos(cosmos-tx-hash),
+  }
+
+  record cosmos-address {
+    bech32-addr: string,
+    /// prefix is the first part of the bech32 address
+    prefix-len: u32,
+  }
+
+  record cosmos-event {
+    ty: string,
+    attributes: list<tuple<string, string>>,
+  }
+
+  record cosmos-chain-config {
+    chain-id: string,
+    rpc-endpoint: option<string>,
+    grpc-endpoint: option<string>,
+    grpc-web-endpoint: option<string>,
+    gas-price: f32,
+    gas-denom: string,
+    bech32-prefix: string,
+  }
+
+  record evm-address {
+    raw-bytes: list<u8>,
+  }
+
+  record evm-event-log-data {
+    /// the raw log topics that can be decoded into an event
+    topics: list<list<u8>>,
+    /// the raw log data that can be decoded into an event
+    data: list<u8>,
+  }
+
+  /// The overall idea is to map alloy_rpc_types_eth::Log<LogData>
+  record evm-event-log {
+    /// These two fields are essentially alloy_primitives::Log<LogData>
+    address: evm-address,
+    data: evm-event-log-data,
+    tx-hash: evm-tx-hash,
+    block-number: u64,
+    log-index: u64,
+    block-hash: list<u8>,
+    /// 256 bytes
+    block-timestamp: option<u64>,
+    tx-index: u64,
+  }
+
+  record evm-chain-config {
+    chain-id: string,
+    ws-endpoints: list<string>,
+    http-endpoint: option<string>,
+  }
+}
+
+interface core {
+  type digest = string;
+
+  record timestamp {
+    nanos: u64,
+  }
+
+  record duration {
+    secs: u64,
+  }
+
+  /// 128-bit unsigned integer represented as two 64-bit values.
+  ///
+  /// The tuple is stored in little-endian order:
+  /// - First element (index 0): Lower 64 bits (bits 0-63)
+  /// - Second element (index 1): Upper 64 bits (bits 64-127)
+  record u128 {
+    value: tuple<u64, u64>,
+  }
+
+  variant log-level {
+    error,
+    warn,
+    info,
+    debug,
+    trace,
+  }
+}
+
+interface events {
+  use chain.{chain-key, evm-address, evm-event-log, cosmos-address, cosmos-event};
+  use core.{timestamp};
+
+  type event-id = list<u8>;
+
+  record trigger-data-evm-contract-event {
+    chain: chain-key,
+    log: evm-event-log,
+  }
+
+  record trigger-data-cosmos-contract-event {
+    contract-address: cosmos-address,
+    chain: chain-key,
+    event: cosmos-event,
+    event-index: u64,
+    block-height: u64,
+  }
+
+  record trigger-data-block-interval {
+    chain: chain-key,
+    block-height: u64,
+  }
+
+  record trigger-data-cron {
+    trigger-time: timestamp,
+  }
+
+  record trigger-data-atproto-event {
+    sequence: s64,
+    timestamp: s64,
+    repo: string,
+    collection: string,
+    rkey: string,
+    action: string,
+    cid: option<string>,
+    record-data: option<string>,
+    rev: option<string>,
+    op-index: option<u32>,
+  }
+
+  record trigger-data-hypercore-append {
+    feed-key: string,
+    index: u64,
+    data: list<u8>,
+  }
+
+  /// 20-byte unique hash
+  variant trigger-data {
+    evm-contract-event(trigger-data-evm-contract-event),
+    cosmos-contract-event(trigger-data-cosmos-contract-event),
+    block-interval(trigger-data-block-interval),
+    cron(trigger-data-cron),
+    atproto-event(trigger-data-atproto-event),
+    hypercore-append(trigger-data-hypercore-append),
+    raw(list<u8>),
+  }
+}
+
+interface service {
+  use core.{digest, timestamp};
+  use chain.{chain-key, evm-address, cosmos-address};
+
+  /// Basic types
+  type service-id = string;
+
+  type workflow-id = string;
+
+  type package-ref = string;
+
+  type semver-version = string;
+
+  variant service-status {
+    active,
+    paused,
+  }
+
+  record evm-manager {
+    chain: chain-key,
+    address: evm-address,
+  }
+
+  record cosmos-manager {
+    chain: chain-key,
+    address: cosmos-address,
+  }
+
+  variant service-manager {
+    evm(evm-manager),
+    cosmos(cosmos-manager),
+  }
+
+  record component-source-download {
+    uri: string,
+    digest: digest,
+  }
+
+  record registry {
+    digest: digest,
+    domain: option<string>,
+    version: option<semver-version>,
+    pkg: package-ref,
+  }
+
+  variant component-source {
+    download(component-source-download),
+    registry(registry),
+    digest(digest),
+  }
+
+  variant allowed-host-permission {
+    all,
+    only(list<string>),
+    none,
+  }
+
+  /// Permissions types
+  record permissions {
+    allowed-http-hosts: allowed-host-permission,
+    file-system: bool,
+    raw-sockets: bool,
+    dns-resolution: bool,
+  }
+
+  /// Component types
+  record component {
+    source: component-source,
+    permissions: permissions,
+    fuel-limit: option<u64>,
+    time-limit-seconds: option<u64>,
+    config: list<tuple<string, string>>,
+    env-keys: list<string>,
+  }
+
+  record trigger-evm-contract-event {
+    address: evm-address,
+    chain: chain-key,
+    event-hash: list<u8>,
+  }
+
+  record trigger-cosmos-contract-event {
+    address: cosmos-address,
+    chain: chain-key,
+    event-type: string,
+  }
+
+  record trigger-block-interval {
+    chain: chain-key,
+    n-blocks: u32,
+    start-block: option<u64>,
+    end-block: option<u64>,
+  }
+
+  record trigger-cron {
+    schedule: string,
+    start-time: option<timestamp>,
+    end-time: option<timestamp>,
+  }
+
+  record trigger-atproto-event {
+    collection: string,
+    repo-did: option<string>,
+    action: option<string>,
+  }
+
+  record trigger-hypercore-append {
+    feed-key: string,
+  }
+
+  /// Trigger types
+  variant trigger {
+    evm-contract-event(trigger-evm-contract-event),
+    cosmos-contract-event(trigger-cosmos-contract-event),
+    block-interval(trigger-block-interval),
+    cron(trigger-cron),
+    atproto-event(trigger-atproto-event),
+    hypercore-append(trigger-hypercore-append),
+    manual,
+  }
+
+  variant signature-algorithm {
+    secp256k1,
+  }
+
+  variant signature-prefix {
+    eip191,
+  }
+
+  record signature-kind {
+    algorithm: signature-algorithm,
+    prefix: option<signature-prefix>,
+  }
+
+  record aggregator-submit {
+    component: component,
+    signature-kind: signature-kind,
+  }
+
+  /// Submit types
+  variant submit {
+    none,
+    aggregator(aggregator-submit),
+  }
+
+  /// Workflow types
+  record workflow {
+    trigger: trigger,
+    component: component,
+    submit: submit,
+  }
+
+  /// Service types
+  record service {
+    name: string,
+    workflows: list<tuple<workflow-id, workflow>>,
+    status: service-status,
+    manager: service-manager,
+  }
+
+  /// Aggregator types
+  record service-and-workflow-id {
+    service: service,
+    workflow-id: workflow-id,
+  }
+
+  record workflow-and-workflow-id {
+    workflow: workflow,
+    workflow-id: workflow-id,
+  }
+}
+

--- a/wit-definitions/operator/wit/deps/wavs-types-2.7.0/package.wit
+++ b/wit-definitions/operator/wit/deps/wavs-types-2.7.0/package.wit
@@ -1,0 +1,330 @@
+package wavs:types@2.7.0;
+
+interface chain {
+  /// A string mostly following the caip-2 format of namespace:reference, e.g. "eip155:1" for Ethereum mainnet or "cosmos:cosmoshub-4" for Cosmos Hub
+  /// however, we allow up to 32 characters for the "namespace" part, and we call the "reference" part "chain-id" to confirm with popular usage
+  type chain-key = string;
+
+  type evm-tx-hash = list<u8>;
+
+  /// 32 bytes, a keccak hash of an RLP encoded signed transaction
+  type cosmos-tx-hash = string;
+
+  variant any-tx-hash {
+    evm(evm-tx-hash),
+    cosmos(cosmos-tx-hash),
+  }
+
+  record cosmos-address {
+    bech32-addr: string,
+    /// prefix is the first part of the bech32 address
+    prefix-len: u32,
+  }
+
+  record cosmos-event {
+    ty: string,
+    attributes: list<tuple<string, string>>,
+  }
+
+  record cosmos-chain-config {
+    chain-id: string,
+    rpc-endpoint: option<string>,
+    grpc-endpoint: option<string>,
+    grpc-web-endpoint: option<string>,
+    gas-price: f32,
+    gas-denom: string,
+    bech32-prefix: string,
+  }
+
+  record evm-address {
+    raw-bytes: list<u8>,
+  }
+
+  record evm-event-log-data {
+    /// the raw log topics that can be decoded into an event
+    topics: list<list<u8>>,
+    /// the raw log data that can be decoded into an event
+    data: list<u8>,
+  }
+
+  /// The overall idea is to map alloy_rpc_types_eth::Log<LogData>
+  record evm-event-log {
+    /// These two fields are essentially alloy_primitives::Log<LogData>
+    address: evm-address,
+    data: evm-event-log-data,
+    tx-hash: evm-tx-hash,
+    block-number: u64,
+    log-index: u64,
+    block-hash: list<u8>,
+    /// 256 bytes
+    block-timestamp: option<u64>,
+    tx-index: u64,
+  }
+
+  record evm-chain-config {
+    chain-id: string,
+    ws-endpoints: list<string>,
+    http-endpoint: option<string>,
+  }
+}
+
+interface core {
+  type digest = string;
+
+  record timestamp {
+    nanos: u64,
+  }
+
+  record duration {
+    secs: u64,
+  }
+
+  /// 128-bit unsigned integer represented as two 64-bit values.
+  ///
+  /// The tuple is stored in little-endian order:
+  /// - First element (index 0): Lower 64 bits (bits 0-63)
+  /// - Second element (index 1): Upper 64 bits (bits 64-127)
+  record u128 {
+    value: tuple<u64, u64>,
+  }
+
+  variant log-level {
+    error,
+    warn,
+    info,
+    debug,
+    trace,
+  }
+}
+
+interface events {
+  use chain.{chain-key, evm-address, evm-event-log, cosmos-address, cosmos-event};
+  use core.{timestamp};
+
+  type event-id = list<u8>;
+
+  record trigger-data-evm-contract-event {
+    chain: chain-key,
+    log: evm-event-log,
+  }
+
+  record trigger-data-cosmos-contract-event {
+    contract-address: cosmos-address,
+    chain: chain-key,
+    event: cosmos-event,
+    event-index: u64,
+    block-height: u64,
+  }
+
+  record trigger-data-block-interval {
+    chain: chain-key,
+    block-height: u64,
+  }
+
+  record trigger-data-cron {
+    trigger-time: timestamp,
+  }
+
+  record trigger-data-atproto-event {
+    sequence: s64,
+    timestamp: s64,
+    repo: string,
+    collection: string,
+    rkey: string,
+    action: string,
+    cid: option<string>,
+    record-data: option<string>,
+    rev: option<string>,
+    op-index: option<u32>,
+  }
+
+  record trigger-data-hypercore-append {
+    feed-key: string,
+    index: u64,
+    data: list<u8>,
+  }
+
+  /// 20-byte unique hash
+  variant trigger-data {
+    evm-contract-event(trigger-data-evm-contract-event),
+    cosmos-contract-event(trigger-data-cosmos-contract-event),
+    block-interval(trigger-data-block-interval),
+    cron(trigger-data-cron),
+    atproto-event(trigger-data-atproto-event),
+    hypercore-append(trigger-data-hypercore-append),
+    raw(list<u8>),
+  }
+}
+
+interface service {
+  use core.{digest, timestamp};
+  use chain.{chain-key, evm-address, cosmos-address};
+
+  /// Basic types
+  type service-id = string;
+
+  type workflow-id = string;
+
+  type package-ref = string;
+
+  type semver-version = string;
+
+  variant service-status {
+    active,
+    paused,
+  }
+
+  record evm-manager {
+    chain: chain-key,
+    address: evm-address,
+  }
+
+  record cosmos-manager {
+    chain: chain-key,
+    address: cosmos-address,
+  }
+
+  variant service-manager {
+    evm(evm-manager),
+    cosmos(cosmos-manager),
+  }
+
+  record component-source-download {
+    uri: string,
+    digest: digest,
+  }
+
+  record registry {
+    digest: digest,
+    domain: option<string>,
+    version: option<semver-version>,
+    pkg: package-ref,
+  }
+
+  variant component-source {
+    download(component-source-download),
+    registry(registry),
+    digest(digest),
+  }
+
+  variant allowed-host-permission {
+    all,
+    only(list<string>),
+    none,
+  }
+
+  /// Permissions types
+  record permissions {
+    allowed-http-hosts: allowed-host-permission,
+    file-system: bool,
+    raw-sockets: bool,
+    dns-resolution: bool,
+  }
+
+  /// Component types
+  record component {
+    source: component-source,
+    permissions: permissions,
+    fuel-limit: option<u64>,
+    time-limit-seconds: option<u64>,
+    config: list<tuple<string, string>>,
+    env-keys: list<string>,
+  }
+
+  record trigger-evm-contract-event {
+    address: evm-address,
+    chain: chain-key,
+    event-hash: list<u8>,
+  }
+
+  record trigger-cosmos-contract-event {
+    address: cosmos-address,
+    chain: chain-key,
+    event-type: string,
+  }
+
+  record trigger-block-interval {
+    chain: chain-key,
+    n-blocks: u32,
+    start-block: option<u64>,
+    end-block: option<u64>,
+  }
+
+  record trigger-cron {
+    schedule: string,
+    start-time: option<timestamp>,
+    end-time: option<timestamp>,
+  }
+
+  record trigger-atproto-event {
+    collection: string,
+    repo-did: option<string>,
+    action: option<string>,
+  }
+
+  record trigger-hypercore-append {
+    feed-key: string,
+  }
+
+  /// Trigger types
+  variant trigger {
+    evm-contract-event(trigger-evm-contract-event),
+    cosmos-contract-event(trigger-cosmos-contract-event),
+    block-interval(trigger-block-interval),
+    cron(trigger-cron),
+    atproto-event(trigger-atproto-event),
+    hypercore-append(trigger-hypercore-append),
+    manual,
+  }
+
+  variant signature-algorithm {
+    secp256k1,
+  }
+
+  variant signature-prefix {
+    eip191,
+  }
+
+  record signature-kind {
+    algorithm: signature-algorithm,
+    prefix: option<signature-prefix>,
+  }
+
+  record aggregator-submit {
+    component: component,
+    signature-kind: signature-kind,
+  }
+
+  /// Submit types
+  variant submit {
+    none,
+    aggregator(aggregator-submit),
+  }
+
+  /// Workflow types
+  record workflow {
+    trigger: trigger,
+    component: component,
+    submit: submit,
+  }
+
+  /// Service types
+  record service {
+    name: string,
+    workflows: list<tuple<workflow-id, workflow>>,
+    status: service-status,
+    manager: service-manager,
+  }
+
+  /// Aggregator types
+  record service-and-workflow-id {
+    service: service,
+    workflow-id: workflow-id,
+  }
+
+  record workflow-and-workflow-id {
+    workflow: workflow,
+    workflow-id: workflow-id,
+  }
+}
+


### PR DESCRIPTION
ref https://github.com/Lay3rLabs/WAVS/actions/runs/22492465905/job/65158109563

Removes wit-definitions/*/wit/deps from .gitignore so WIT dependencies are checked into the repo. This eliminates the need to install wkg, configure the wasm-pkg registry, and run `just wit-deps-fetch` in CI, simplifying all jobs in basic.yml and making builds reproducible.

Deps are small and don't frequently change, so it should be fine to continue tracking them here.