### PR TITLE
WAVS App feat: component log observability (Phase 1)

### DIFF
--- a/packages/cli/src/command/exec_aggregator.rs
+++ b/packages/cli/src/command/exec_aggregator.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
 use std::time::Instant;
 use utils::config::WAVS_ENV_PREFIX;
 use wavs_engine::worlds::instance::{HostComponentLogger, InstanceData, InstanceDepsBuilder};
@@ -130,7 +131,7 @@ impl ExecAggregator {
             engine: &engine,
             data_dir: tempfile::tempdir()?.keep(),
             chain_configs: &cli_config.chains.read().unwrap(),
-            log: HostComponentLogger::AggregatorHostComponentLogger(
+            log: HostComponentLogger::AggregatorHostComponentLogger(Arc::new(
                 |_service_id, _workflow_id, _digest, level, message| {
                     match level {
                 wavs_engine::bindings::aggregator::world::wavs::types::core::LogLevel::Error => {
@@ -150,7 +151,7 @@ impl ExecAggregator {
                 }
             }
                 },
-            ),
+            )),
             keyvalue_ctx: wavs_engine::backend::wasi_keyvalue::context::KeyValueCtx::new(
                 utils::storage::db::WavsDb::new()?,
                 service.id().to_string(),

--- a/packages/cli/src/command/exec_component.rs
+++ b/packages/cli/src/command/exec_component.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::BTreeMap,
+    sync::Arc,
     time::{Instant, SystemTime, UNIX_EPOCH},
 };
 
@@ -208,7 +209,7 @@ impl ExecComponent {
             engine: &engine,
             data_dir: tempfile::tempdir()?.keep(),
             chain_configs: &cli_config.chains.read().unwrap(),
-            log: HostComponentLogger::OperatorHostComponentLogger(log_wasi),
+            log: HostComponentLogger::OperatorHostComponentLogger(Arc::new(log_wasi)),
             keyvalue_ctx: wavs_engine::backend::wasi_keyvalue::context::KeyValueCtx::new(
                 WavsDb::new().unwrap(),
                 "exec_component".to_string(),

--- a/packages/engine/src/worlds/aggregator/component.rs
+++ b/packages/engine/src/worlds/aggregator/component.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use wasmtime_wasi::{WasiCtx, WasiCtxView, WasiView};
 use wasmtime_wasi_http::{WasiHttpCtx, WasiHttpView};
 use wasmtime_wasi_tls::WasiTlsCtx;
@@ -7,8 +9,10 @@ use crate::{
     backend::wasi_keyvalue::context::KeyValueCtx, bindings::aggregator::world::host::LogLevel,
 };
 
+// Using Arc<dyn Fn> instead of a bare fn pointer allows callers to capture
+// context (e.g. a ComponentLogBuffer) in the logger callback.
 pub type AggregatorHostComponentLogger =
-    fn(&ServiceId, &WorkflowId, &ComponentDigest, LogLevel, String);
+    Arc<dyn Fn(&ServiceId, &WorkflowId, &ComponentDigest, LogLevel, String) + Send + Sync>;
 
 pub struct AggregatorHostComponent {
     pub service: Service,

--- a/packages/engine/src/worlds/operator/component.rs
+++ b/packages/engine/src/worlds/operator/component.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use wasmtime_wasi::{WasiCtx, WasiCtxView, WasiView};
 use wasmtime_wasi_http::{WasiHttpCtx, WasiHttpView};
 use wasmtime_wasi_tls::WasiTlsCtx;
@@ -6,9 +8,11 @@ use wavs_types::{ChainConfigs, ComponentDigest, Service, ServiceId, TriggerData,
 use crate::backend::wasi_keyvalue::context::KeyValueCtx;
 use crate::bindings::operator::world::host::LogLevel;
 
-// This is defined separately because LogLevel comes from bindings
+// This is defined separately because LogLevel comes from bindings.
+// Using Arc<dyn Fn> instead of a bare fn pointer allows callers to capture
+// context (e.g. a ComponentLogBuffer) in the logger callback.
 pub type OperatorHostComponentLogger =
-    fn(&ServiceId, &WorkflowId, &ComponentDigest, LogLevel, String);
+    Arc<dyn Fn(&ServiceId, &WorkflowId, &ComponentDigest, LogLevel, String) + Send + Sync>;
 
 // TODO: revisit this an understand it.
 // Copied blindly from old code

--- a/packages/engine/tests/helpers/aggregator_exec.rs
+++ b/packages/engine/tests/helpers/aggregator_exec.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use utils::storage::db::WavsDb;
 use wasmtime::{component::Component as WasmtimeComponent, Config as WTConfig, Engine as WTEngine};
 use wavs_engine::{
@@ -49,7 +51,7 @@ pub async fn execute_aggregator_component(
         engine: &engine,
         data_dir: data_dir.path().to_path_buf(),
         chain_configs: &chain_configs,
-        log: HostComponentLogger::AggregatorHostComponentLogger(log_aggregator),
+        log: HostComponentLogger::AggregatorHostComponentLogger(Arc::new(log_aggregator)),
         keyvalue_ctx,
     }
     .build()

--- a/packages/engine/tests/helpers/exec.rs
+++ b/packages/engine/tests/helpers/exec.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use alloy_sol_types::SolValue;
 use serde::{de::DeserializeOwned, Serialize};
@@ -96,7 +97,7 @@ pub async fn try_execute_component_raw(
         engine: &engine,
         data_dir: data_dir.path().to_path_buf(),
         chain_configs: &Default::default(),
-        log: HostComponentLogger::OperatorHostComponentLogger(log_wasi),
+        log: HostComponentLogger::OperatorHostComponentLogger(Arc::new(log_wasi)),
         keyvalue_ctx,
     }
     .build()

--- a/packages/utils/src/storage/db.rs
+++ b/packages/utils/src/storage/db.rs
@@ -7,6 +7,8 @@ use tracing::instrument;
 
 use wavs_types::{QuorumQueue, QuorumQueueId, Service, ServiceId};
 
+use super::log_buffer::ComponentLogBuffer;
+
 /// Main database struct with hardcoded tables for better type safety and performance
 #[derive(Clone)]
 pub struct WavsDb {
@@ -16,6 +18,9 @@ pub struct WavsDb {
     pub quorum_queues: WavsDbTable<QuorumQueueId, QuorumQueue>,
     pub kv_store: WavsDbTable<String, Vec<u8>>,
     pub kv_atomics_counter: WavsDbTable<String, i64>,
+    /// Bounded in-memory ring buffer of component log entries.
+    /// All clones of `WavsDb` share the same underlying buffer (Arc-backed).
+    pub component_logs: ComponentLogBuffer,
 }
 
 impl WavsDb {
@@ -30,6 +35,7 @@ impl WavsDb {
             quorum_queues: WavsDbTable::new()?,
             kv_store: WavsDbTable::new()?,
             kv_atomics_counter: WavsDbTable::new()?,
+            component_logs: ComponentLogBuffer::default(),
         })
     }
 }

--- a/packages/utils/src/storage/log_buffer.rs
+++ b/packages/utils/src/storage/log_buffer.rs
@@ -1,0 +1,217 @@
+//! In-memory ring buffer for component log entries.
+//!
+//! Each call to `host.log()` inside a WASM component currently emits a tracing
+//! event tagged with `service_id`, `workflow_id`, and `component_digest`. That
+//! output ends up in the WAVS node's stdout/stderr mix with no way for a developer
+//! to query "what did _this_ service log on trigger X?".
+//!
+//! This module provides `ComponentLogBuffer`: a bounded, per-service ring buffer
+//! that captures every `host.log()` call alongside the regular tracing pipeline.
+//! It is `Clone` (wraps an `Arc`) so a single instance can be shared cheaply
+//! between the engine and the HTTP server state.
+//!
+//! `WavsDb` holds a `ComponentLogBuffer`; both `WasmEngine` and `HttpState`
+//! receive the same `WavsDb` clone, so they see the same log data.
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use wavs_types::{ComponentDigest, ServiceId, WorkflowId};
+
+/// Default maximum number of log entries retained per service.
+/// Once the buffer is full, the oldest entry is dropped.
+pub const DEFAULT_MAX_LOG_ENTRIES_PER_SERVICE: usize = 500;
+
+/// Log severity level, mirroring the WIT `log-level` enum.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ComponentLogLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl ComponentLogLevel {
+    /// Numeric rank: higher = more severe. Used for minimum-level filtering.
+    pub fn rank(&self) -> u8 {
+        match self {
+            ComponentLogLevel::Trace => 0,
+            ComponentLogLevel::Debug => 1,
+            ComponentLogLevel::Info => 2,
+            ComponentLogLevel::Warn => 3,
+            ComponentLogLevel::Error => 4,
+        }
+    }
+
+    pub fn from_str_lossy(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "error" => Some(ComponentLogLevel::Error),
+            "warn" | "warning" => Some(ComponentLogLevel::Warn),
+            "info" => Some(ComponentLogLevel::Info),
+            "debug" => Some(ComponentLogLevel::Debug),
+            "trace" => Some(ComponentLogLevel::Trace),
+            _ => None,
+        }
+    }
+}
+
+/// Whether the log entry came from an operator or aggregator component.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ComponentKind {
+    Operator,
+    Aggregator,
+}
+
+/// A single captured log entry from a WASM component.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct LogEntry {
+    /// Unix milliseconds when the entry was captured.
+    pub timestamp_ms: u64,
+    pub level: ComponentLogLevel,
+    /// String representation of the `ServiceId`.
+    pub service_id: String,
+    /// String representation of the `WorkflowId`.
+    pub workflow_id: String,
+    /// Hex-encoded component digest.
+    pub digest: String,
+    /// Hex-encoded `EventId` for this trigger execution.
+    /// Present for aggregator components; `None` for operator components.
+    pub event_id: Option<String>,
+    pub component_kind: ComponentKind,
+    pub message: String,
+}
+
+/// Bounded in-memory ring buffer of component log entries, keyed by `ServiceId`.
+///
+/// All fields are `Arc`-backed so cloning is `O(1)` and all clones share
+/// the same underlying data.
+#[derive(Clone)]
+pub struct ComponentLogBuffer {
+    entries: Arc<DashMap<ServiceId, VecDeque<LogEntry>>>,
+    max_per_service: usize,
+}
+
+impl ComponentLogBuffer {
+    pub fn new(max_per_service: usize) -> Self {
+        Self {
+            entries: Arc::new(DashMap::new()),
+            max_per_service,
+        }
+    }
+
+    /// Append a log entry, dropping the oldest if the buffer is full.
+    pub fn push(&self, service_id: ServiceId, entry: LogEntry) {
+        let mut queue = self.entries.entry(service_id).or_default();
+        if queue.len() >= self.max_per_service {
+            queue.pop_front();
+        }
+        queue.push_back(entry);
+    }
+
+    /// Query log entries for a service with optional filters.
+    ///
+    /// Results are returned newest-first and capped at `limit`.
+    pub fn query(
+        &self,
+        service_id: &ServiceId,
+        since_ms: Option<u64>,
+        min_level: Option<&ComponentLogLevel>,
+        workflow_id: Option<&str>,
+        limit: usize,
+    ) -> Vec<LogEntry> {
+        let min_rank = min_level.map(|l| l.rank()).unwrap_or(0);
+        match self.entries.get(service_id) {
+            None => vec![],
+            Some(queue) => queue
+                .iter()
+                .filter(|e| {
+                    let level_ok = e.level.rank() >= min_rank;
+                    let since_ok = since_ms.map_or(true, |ms| e.timestamp_ms >= ms);
+                    let wf_ok = workflow_id.map_or(true, |wf| e.workflow_id == wf);
+                    level_ok && since_ok && wf_ok
+                })
+                .rev()
+                .take(limit)
+                .cloned()
+                .collect(),
+        }
+    }
+
+    /// Return all log entries associated with a specific trigger execution.
+    pub fn query_by_event(&self, service_id: &ServiceId, event_id: &str) -> Vec<LogEntry> {
+        match self.entries.get(service_id) {
+            None => vec![],
+            Some(queue) => queue
+                .iter()
+                .filter(|e| e.event_id.as_deref() == Some(event_id))
+                .cloned()
+                .collect(),
+        }
+    }
+
+    /// Remove all log entries for a service (e.g., on service deletion).
+    pub fn clear_service(&self, service_id: &ServiceId) {
+        self.entries.remove(service_id);
+    }
+}
+
+impl Default for ComponentLogBuffer {
+    fn default() -> Self {
+        Self::new(DEFAULT_MAX_LOG_ENTRIES_PER_SERVICE)
+    }
+}
+
+fn current_timestamp_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+/// Build a `LogEntry` for an operator component invocation.
+pub fn make_operator_log_entry(
+    service_id: &ServiceId,
+    workflow_id: &WorkflowId,
+    digest: &ComponentDigest,
+    level: ComponentLogLevel,
+    message: String,
+) -> LogEntry {
+    LogEntry {
+        timestamp_ms: current_timestamp_ms(),
+        level,
+        service_id: service_id.to_string(),
+        workflow_id: workflow_id.to_string(),
+        digest: digest.to_string(),
+        event_id: None,
+        component_kind: ComponentKind::Operator,
+        message,
+    }
+}
+
+/// Build a `LogEntry` for an aggregator component invocation.
+pub fn make_aggregator_log_entry(
+    service_id: &ServiceId,
+    workflow_id: &WorkflowId,
+    digest: &ComponentDigest,
+    event_id: &wavs_types::EventId,
+    level: ComponentLogLevel,
+    message: String,
+) -> LogEntry {
+    LogEntry {
+        timestamp_ms: current_timestamp_ms(),
+        level,
+        service_id: service_id.to_string(),
+        workflow_id: workflow_id.to_string(),
+        digest: digest.to_string(),
+        event_id: Some(event_id.to_string()),
+        component_kind: ComponentKind::Aggregator,
+        message,
+    }
+}

--- a/packages/utils/src/storage/mod.rs
+++ b/packages/utils/src/storage/mod.rs
@@ -3,6 +3,7 @@ pub use prelude::*;
 
 pub mod db;
 pub mod fs;
+pub mod log_buffer;
 pub mod memory;
 
 #[cfg(test)]

--- a/packages/wavs/benches/common/src/engine_setup.rs
+++ b/packages/wavs/benches/common/src/engine_setup.rs
@@ -108,11 +108,11 @@ impl EngineSetup {
 
     /// Create a new InstanceDeps for execution
     pub fn create_instance_deps(&self, trigger_action: &TriggerAction) -> InstanceDeps {
-        let log = HostComponentLogger::OperatorHostComponentLogger(
+        let log = HostComponentLogger::OperatorHostComponentLogger(Arc::new(
             |_service_id, _workflow_id, _digest, _level, _message| {
                 // No-op logger for benchmarks
             },
-        );
+        ));
 
         let builder = InstanceDepsBuilder {
             component: self.component.clone(),

--- a/packages/wavs/src/http/handlers/logs.rs
+++ b/packages/wavs/src/http/handlers/logs.rs
@@ -67,16 +67,17 @@ pub async fn handle_get_logs(
     Path(service_id_str): Path<String>,
     Query(params): Query<LogsQuery>,
 ) -> impl IntoResponse {
-    let service_id = match ServiceId::from_str(&service_id_str) {
-        Ok(id) => id,
-        Err(_) => {
-            return (
+    let service_id =
+        match ServiceId::from_str(&service_id_str) {
+            Ok(id) => id,
+            Err(_) => return (
                 StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({"error": "invalid service_id: expected 32-byte hex string"})),
+                Json(
+                    serde_json::json!({"error": "invalid service_id: expected 32-byte hex string"}),
+                ),
             )
-                .into_response()
-        }
-    };
+                .into_response(),
+        };
 
     let limit = params.limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT);
 
@@ -121,16 +122,17 @@ pub async fn handle_get_logs_by_event(
     State(state): State<HttpState>,
     Path((service_id_str, event_id)): Path<(String, String)>,
 ) -> impl IntoResponse {
-    let service_id = match ServiceId::from_str(&service_id_str) {
-        Ok(id) => id,
-        Err(_) => {
-            return (
+    let service_id =
+        match ServiceId::from_str(&service_id_str) {
+            Ok(id) => id,
+            Err(_) => return (
                 StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({"error": "invalid service_id: expected 32-byte hex string"})),
+                Json(
+                    serde_json::json!({"error": "invalid service_id: expected 32-byte hex string"}),
+                ),
             )
-                .into_response()
-        }
-    };
+                .into_response(),
+        };
 
     let entries = state
         .db_storage

--- a/packages/wavs/src/http/handlers/logs.rs
+++ b/packages/wavs/src/http/handlers/logs.rs
@@ -1,0 +1,141 @@
+//! HTTP handlers for `GET /dev/logs/{service_id}` and
+//! `GET /dev/logs/{service_id}/events/{event_id}`.
+//!
+//! These endpoints expose the in-memory component log ring buffer so developers
+//! can query what a WASM component emitted via `host.log()` without tailing
+//! the WAVS node's raw stdout.
+
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde::Deserialize;
+use std::str::FromStr;
+use utils::storage::log_buffer::ComponentLogLevel;
+use wavs_types::ServiceId;
+
+use crate::http::state::HttpState;
+
+// ---------------------------------------------------------------------------
+// Query parameter types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct LogsQuery {
+    /// Return only entries at or after this Unix millisecond timestamp.
+    pub since: Option<u64>,
+    /// Minimum log level to include (error | warn | info | debug | trace).
+    pub level: Option<String>,
+    /// Restrict to a specific workflow within the service.
+    pub workflow_id: Option<String>,
+    /// Maximum number of entries to return (default 50, max 500).
+    pub limit: Option<usize>,
+}
+
+const DEFAULT_LIMIT: usize = 50;
+const MAX_LIMIT: usize = 500;
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// List log entries for a service.
+///
+/// `GET /dev/logs/{service_id}?since=<ms>&level=<level>&workflow_id=<id>&limit=<n>`
+///
+/// Results are returned newest-first, capped at `limit` (default 50, max 500).
+#[utoipa::path(
+    get,
+    path = "/dev/logs/{service_id}",
+    params(
+        ("service_id" = String, Path, description = "Service ID"),
+        ("since"       = Option<u64>, Query, description = "Unix millisecond lower bound"),
+        ("level"       = Option<String>, Query, description = "Minimum level: error|warn|info|debug|trace"),
+        ("workflow_id" = Option<String>, Query, description = "Filter by workflow ID"),
+        ("limit"       = Option<usize>, Query, description = "Max entries (default 50, max 500)"),
+    ),
+    responses(
+        (status = 200, description = "Log entries", body = Vec<utils::storage::log_buffer::LogEntry>),
+    ),
+    description = "Query buffered component log entries for a service"
+)]
+#[axum::debug_handler]
+pub async fn handle_get_logs(
+    State(state): State<HttpState>,
+    Path(service_id_str): Path<String>,
+    Query(params): Query<LogsQuery>,
+) -> impl IntoResponse {
+    let service_id = match ServiceId::from_str(&service_id_str) {
+        Ok(id) => id,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "invalid service_id: expected 32-byte hex string"})),
+            )
+                .into_response()
+        }
+    };
+
+    let limit = params.limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT);
+
+    let min_level = params
+        .level
+        .as_deref()
+        .and_then(ComponentLogLevel::from_str_lossy);
+
+    let entries = state.db_storage.component_logs.query(
+        &service_id,
+        params.since,
+        min_level.as_ref(),
+        params.workflow_id.as_deref(),
+        limit,
+    );
+
+    (StatusCode::OK, Json(entries)).into_response()
+}
+
+/// List log entries for a specific trigger execution.
+///
+/// `GET /dev/logs/{service_id}/events/{event_id}`
+///
+/// Returns all buffered log entries (operator + aggregator) whose `event_id`
+/// matches. Operator logs don't carry an `event_id`, so only aggregator
+/// entries will appear here.
+#[utoipa::path(
+    get,
+    path = "/dev/logs/{service_id}/events/{event_id}",
+    params(
+        ("service_id" = String, Path, description = "Service ID"),
+        ("event_id"   = String, Path, description = "Hex-encoded EventId (20 bytes)"),
+    ),
+    responses(
+        (status = 200, description = "Log entries for the trigger execution",
+         body = Vec<utils::storage::log_buffer::LogEntry>),
+    ),
+    description = "Query buffered component log entries for a specific trigger execution"
+)]
+#[axum::debug_handler]
+pub async fn handle_get_logs_by_event(
+    State(state): State<HttpState>,
+    Path((service_id_str, event_id)): Path<(String, String)>,
+) -> impl IntoResponse {
+    let service_id = match ServiceId::from_str(&service_id_str) {
+        Ok(id) => id,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "invalid service_id: expected 32-byte hex string"})),
+            )
+                .into_response()
+        }
+    };
+
+    let entries = state
+        .db_storage
+        .component_logs
+        .query_by_event(&service_id, &event_id);
+
+    (StatusCode::OK, Json(entries)).into_response()
+}

--- a/packages/wavs/src/http/handlers/mod.rs
+++ b/packages/wavs/src/http/handlers/mod.rs
@@ -5,6 +5,7 @@ pub mod fs;
 mod health;
 mod info;
 pub mod kv;
+pub mod logs;
 mod not_found;
 pub(crate) mod openapi;
 mod p2p;

--- a/packages/wavs/src/http/handlers/service/add.rs
+++ b/packages/wavs/src/http/handlers/service/add.rs
@@ -1,22 +1,29 @@
 use axum::{extract::State, response::IntoResponse, Json};
 use reqwest::StatusCode;
+use serde::Serialize;
+use utoipa::ToSchema;
 
 use crate::http::{
     error::HttpResult, handlers::service::get::get_service_inner_hash, state::HttpState,
 };
-use wavs_types::{AddServiceRequest, ServiceManager};
+use wavs_types::{AddServiceRequest, ServiceId, ServiceManager};
+
+#[derive(Serialize, ToSchema)]
+struct AddServiceResponse {
+    service_id: ServiceId,
+}
 
 #[utoipa::path(
     post,
     path = "/services",
     request_body = AddServiceRequest,
     responses(
-        (status = 204, description = "Service successfully added"),
+        (status = 200, description = "Service successfully added", body = AddServiceResponse),
         (status = 400, description = "Invalid service configuration"),
         (status = 409, description = "Service already exists"),
         (status = 500, description = "Internal server error")
     ),
-    description = "Registers a new service with WAVS"
+    description = "Registers a new service with WAVS. Returns the service_id for use with /dev/logs and other service endpoints."
 )]
 #[axum::debug_handler]
 pub async fn handle_add_service(
@@ -24,17 +31,20 @@ pub async fn handle_add_service(
     Json(req): Json<AddServiceRequest>,
 ) -> impl IntoResponse {
     match add_service_inner(state, req.service_manager).await {
-        Ok(_) => StatusCode::NO_CONTENT.into_response(),
+        Ok(service_id) => (StatusCode::OK, Json(AddServiceResponse { service_id })).into_response(),
         Err(e) => e.into_response(),
     }
 }
 
-async fn add_service_inner(state: HttpState, service_manager: ServiceManager) -> HttpResult<()> {
-    state.dispatcher.add_service(service_manager).await?;
+async fn add_service_inner(
+    state: HttpState,
+    service_manager: ServiceManager,
+) -> HttpResult<ServiceId> {
+    let service = state.dispatcher.add_service(service_manager).await?;
 
     state.metrics.increment_registered_services();
 
-    Ok(())
+    Ok(service.id())
 }
 
 #[utoipa::path(

--- a/packages/wavs/src/http/server.rs
+++ b/packages/wavs/src/http/server.rs
@@ -29,6 +29,7 @@ use super::{
         handle_info, handle_list_services, handle_not_found, handle_p2p_status,
         handle_upload_component,
         kv::{handle_get_kv, handle_list_kv},
+        logs::{handle_get_logs, handle_get_logs_by_event},
         openapi::ApiDoc,
         service::{
             get::handle_get_service,
@@ -128,7 +129,12 @@ pub async fn make_router(
             .route("/dev/kv/{service_id}/{bucket}/{key}", get(handle_get_kv))
             .route("/dev/kv/{service_id}", get(handle_list_kv))
             .route("/dev/fs/{service_id}", get(handle_fs_root))
-            .route("/dev/fs/{service_id}/{*path}", get(handle_fs));
+            .route("/dev/fs/{service_id}/{*path}", get(handle_fs))
+            .route("/dev/logs/{service_id}", get(handle_get_logs))
+            .route(
+                "/dev/logs/{service_id}/events/{event_id}",
+                get(handle_get_logs_by_event),
+            );
 
         protected = protected
             .route("/dev/triggers", post(handle_debug_trigger))

--- a/packages/wavs/src/subsystems/engine/wasm_engine.rs
+++ b/packages/wavs/src/subsystems/engine/wasm_engine.rs
@@ -3,6 +3,9 @@ use std::time::Instant;
 use std::{path::Path, sync::RwLock};
 use tracing::{event, instrument, span};
 use utils::storage::db::WavsDb;
+use utils::storage::log_buffer::{
+    make_aggregator_log_entry, make_operator_log_entry, ComponentLogLevel,
+};
 use utils::telemetry::EngineMetrics;
 use wavs_engine::bindings::aggregator::world::wavs::types::chain::AnyTxHash;
 use wavs_engine::{
@@ -135,6 +138,24 @@ impl<S: CAStorage + Send + Sync + 'static> WasmEngine<S> {
         let service_id = service.id();
         let workflow_id = trigger_action.config.workflow_id.clone();
 
+        let log_buffer = self.engine.db.component_logs.clone();
+        let op_logger = Arc::new(
+            move |svc_id: &ServiceId,
+                  wf_id: &WorkflowId,
+                  dgst: &ComponentDigest,
+                  level: wavs_engine::bindings::operator::world::host::LogLevel,
+                  message: String| {
+                let cl = map_operator_log_level(level);
+                // Push to in-process log buffer (queryable via GET /dev/logs/{service_id})
+                log_buffer.push(
+                    svc_id.clone(),
+                    make_operator_log_entry(svc_id, wf_id, dgst, cl.clone(), message.clone()),
+                );
+                // Also emit tracing event (existing behaviour)
+                log_to_tracing_operator(svc_id, wf_id, dgst, cl, &message);
+            },
+        );
+
         let mut instance_deps = InstanceDepsBuilder {
             keyvalue_ctx: KeyValueCtx::new(self.engine.db.clone(), service.id().to_string()),
             service,
@@ -149,7 +170,7 @@ impl<S: CAStorage + Send + Sync + 'static> WasmEngine<S> {
                 .app_data_dir
                 .join(trigger_action.config.service_id.to_string()),
             chain_configs: &chain_configs,
-            log: HostComponentLogger::OperatorHostComponentLogger(log_operator),
+            log: HostComponentLogger::OperatorHostComponentLogger(op_logger),
         }
         .build()?;
 
@@ -427,6 +448,32 @@ impl<S: CAStorage + Send + Sync + 'static> WasmEngine<S> {
 
         let component = self.engine.load_component(&digest).await?;
 
+        let log_buffer = self.engine.db.component_logs.clone();
+        let event_id_for_log = event_id.clone();
+        let agg_logger = Arc::new(
+            move |svc_id: &ServiceId,
+                  wf_id: &WorkflowId,
+                  dgst: &ComponentDigest,
+                  level: wavs_engine::bindings::aggregator::world::host::LogLevel,
+                  message: String| {
+                let cl = map_aggregator_log_level(level);
+                // Push to in-process log buffer (queryable via GET /dev/logs/{service_id}/events/{event_id})
+                log_buffer.push(
+                    svc_id.clone(),
+                    make_aggregator_log_entry(
+                        svc_id,
+                        wf_id,
+                        dgst,
+                        &event_id_for_log,
+                        cl.clone(),
+                        message.clone(),
+                    ),
+                );
+                // Also emit tracing event (existing behaviour)
+                log_to_tracing_aggregator(svc_id, wf_id, dgst, cl, &message);
+            },
+        );
+
         let instance_deps = InstanceDepsBuilder {
             keyvalue_ctx: KeyValueCtx::new(self.engine.db.clone(), service.id().to_string()),
             workflow_id: trigger_action.config.workflow_id.clone(),
@@ -438,7 +485,7 @@ impl<S: CAStorage + Send + Sync + 'static> WasmEngine<S> {
                 .app_data_dir
                 .join(trigger_action.config.service_id.to_string()),
             chain_configs: &chain_configs,
-            log: HostComponentLogger::AggregatorHostComponentLogger(log_aggregator),
+            log: HostComponentLogger::AggregatorHostComponentLogger(agg_logger),
             service,
         }
         .build()?;
@@ -482,71 +529,79 @@ struct AggregatorDeps {
     input: AggregatorInput,
 }
 
-fn log_operator(
-    service_id: &ServiceId,
-    workflow_id: &WorkflowId,
-    digest: &ComponentDigest,
+/// Map the operator WIT `LogLevel` to our canonical `ComponentLogLevel`.
+fn map_operator_log_level(
     level: wavs_engine::bindings::operator::world::host::LogLevel,
-    message: String,
-) {
-    let span = span!(
-        tracing::Level::INFO,
-        "component_log",
-        service_id = %service_id,
-        workflow_id = %workflow_id,
-        digest = %digest
-    );
-
+) -> ComponentLogLevel {
+    use wavs_engine::bindings::operator::world::host::LogLevel;
     match level {
-        wavs_engine::bindings::operator::world::host::LogLevel::Error => {
-            event!(parent: &span, tracing::Level::ERROR, "{}", message)
-        }
-        wavs_engine::bindings::operator::world::host::LogLevel::Warn => {
-            event!(parent: &span, tracing::Level::WARN, "{}", message)
-        }
-        wavs_engine::bindings::operator::world::host::LogLevel::Info => {
-            event!(parent: &span, tracing::Level::INFO, "{}", message)
-        }
-        wavs_engine::bindings::operator::world::host::LogLevel::Debug => {
-            event!(parent: &span, tracing::Level::DEBUG, "{}", message)
-        }
-        wavs_engine::bindings::operator::world::host::LogLevel::Trace => {
-            event!(parent: &span, tracing::Level::TRACE, "{}", message)
-        }
+        LogLevel::Error => ComponentLogLevel::Error,
+        LogLevel::Warn => ComponentLogLevel::Warn,
+        LogLevel::Info => ComponentLogLevel::Info,
+        LogLevel::Debug => ComponentLogLevel::Debug,
+        LogLevel::Trace => ComponentLogLevel::Trace,
     }
 }
 
-fn log_aggregator(
+/// Map the aggregator WIT `LogLevel` to our canonical `ComponentLogLevel`.
+fn map_aggregator_log_level(
+    level: wavs_engine::bindings::aggregator::world::host::LogLevel,
+) -> ComponentLogLevel {
+    use wavs_engine::bindings::aggregator::world::host::LogLevel;
+    match level {
+        LogLevel::Error => ComponentLogLevel::Error,
+        LogLevel::Warn => ComponentLogLevel::Warn,
+        LogLevel::Info => ComponentLogLevel::Info,
+        LogLevel::Debug => ComponentLogLevel::Debug,
+        LogLevel::Trace => ComponentLogLevel::Trace,
+    }
+}
+
+/// Emit a structured tracing event for an operator component log message.
+fn log_to_tracing_operator(
     service_id: &ServiceId,
     workflow_id: &WorkflowId,
     digest: &ComponentDigest,
-    level: wavs_engine::bindings::aggregator::world::host::LogLevel,
-    message: String,
+    level: ComponentLogLevel,
+    message: &str,
 ) {
-    let span = span!(
+    let sp = span!(
         tracing::Level::INFO,
         "component_log",
         service_id = %service_id,
         workflow_id = %workflow_id,
         digest = %digest
     );
-
     match level {
-        wavs_engine::bindings::aggregator::world::host::LogLevel::Error => {
-            event!(parent: &span, tracing::Level::ERROR, "{}", message)
-        }
-        wavs_engine::bindings::aggregator::world::host::LogLevel::Warn => {
-            event!(parent: &span, tracing::Level::WARN, "{}", message)
-        }
-        wavs_engine::bindings::aggregator::world::host::LogLevel::Info => {
-            event!(parent: &span, tracing::Level::INFO, "{}", message)
-        }
-        wavs_engine::bindings::aggregator::world::host::LogLevel::Debug => {
-            event!(parent: &span, tracing::Level::DEBUG, "{}", message)
-        }
-        wavs_engine::bindings::aggregator::world::host::LogLevel::Trace => {
-            event!(parent: &span, tracing::Level::TRACE, "{}", message)
-        }
+        ComponentLogLevel::Error => event!(parent: &sp, tracing::Level::ERROR, "{}", message),
+        ComponentLogLevel::Warn => event!(parent: &sp, tracing::Level::WARN, "{}", message),
+        ComponentLogLevel::Info => event!(parent: &sp, tracing::Level::INFO, "{}", message),
+        ComponentLogLevel::Debug => event!(parent: &sp, tracing::Level::DEBUG, "{}", message),
+        ComponentLogLevel::Trace => event!(parent: &sp, tracing::Level::TRACE, "{}", message),
+    }
+}
+
+/// Emit a structured tracing event for an aggregator component log message.
+fn log_to_tracing_aggregator(
+    service_id: &ServiceId,
+    workflow_id: &WorkflowId,
+    digest: &ComponentDigest,
+    level: ComponentLogLevel,
+    message: &str,
+) {
+    let sp = span!(
+        tracing::Level::INFO,
+        "component_log",
+        service_id = %service_id,
+        workflow_id = %workflow_id,
+        digest = %digest
+    );
+    match level {
+        ComponentLogLevel::Error => event!(parent: &sp, tracing::Level::ERROR, "{}", message),
+        ComponentLogLevel::Warn => event!(parent: &sp, tracing::Level::WARN, "{}", message),
+        ComponentLogLevel::Info => event!(parent: &sp, tracing::Level::INFO, "{}", message),
+        ComponentLogLevel::Debug => event!(parent: &sp, tracing::Level::DEBUG, "{}", message),
+        ComponentLogLevel::Trace => event!(parent: &sp, tracing::Level::TRACE, "{}", message),
     }
 }
 


### PR DESCRIPTION
From our newly emerging WAVS agent... this was its most requested WAVS feature.

====

Add queryable in-memory ring buffer for component log entries emitted via host.log(). Closes the gap between 'I wrote a log' and 'I can actually read it' without a Jaeger stack or node SSH access.

## What changed

### New: ComponentLogBuffer (utils/src/storage/log_buffer.rs)
- Bounded ring buffer (default 500 entries/service) backed by Arc<DashMap>
- LogEntry: timestamp_ms, level, service_id, workflow_id, digest, event_id (aggregator only), component_kind, message
- query() with since_ms / min_level / workflow_id / limit filters
- query_by_event() correlates all aggregator logs for a trigger execution
- clear_service() for cleanup on service deletion

### Modified: WavsDb
- Added component_logs: ComponentLogBuffer field
- All WavsDb clones share the same buffer (Arc-backed)

### Modified: engine logger types
- OperatorHostComponentLogger / AggregatorHostComponentLogger changed from fn(...) to Arc<dyn Fn(...) + Send + Sync>
- Enables closures capturing ComponentLogBuffer at construction time
- Callers that do not need buffer state just wrap with Arc::new(fn)

### Modified: WasmEngine (wasm_engine.rs)
- execute_operator_component: builds closure capturing db.component_logs
- get_aggregator_deps: captures event_id in closure for correlation
- Both paths push to buffer AND emit existing tracing events
- log_operator/log_aggregator replaced with cleaner helpers

### New: HTTP endpoints (dev-only)
- GET /dev/logs/{service_id} ?since=<unix_ms> &level=<error|warn|info|debug|trace> &workflow_id=<id> &limit=<n (default 50, max 500)>
- GET /dev/logs/{service_id}/events/{event_id}

## Follow-ups
- Phase 2: persist component_logs across node restarts
- Phase 3: OTEL span enrichment with event_id + trigger_type
- MCP tool: wavs_get_logs(service_id, ...)