### PR TITLE
Fix wavs-types BLS feature build

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -62,3 +62,6 @@ jobs:
 
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Check wavs-types standalone feature builds
+        run: cargo check -p wavs-types --no-default-features --features full --locked

--- a/packages/types/Cargo.toml
+++ b/packages/types/Cargo.toml
@@ -55,7 +55,7 @@ alloy-signer-local = { workspace = true, optional = true }
 commonware-cryptography = { workspace = true, optional = true }
 blst = { version = "0.3.16", optional = true }
 commonware-codec = { version = "2026.3.0", optional = true }
-tokio = { version = "1", optional = true, default-features = false, features = ["sync"] }
+tokio = { version = "1", optional = true, default-features = false, features = ["sync", "rt"] }
 cosmwasm-schema = { workspace = true, optional = true }
 ts-rs = { version = "11.1", features = ["serde-compat"], optional = true }
 


### PR DESCRIPTION
## Summary

Fixes the standalone `wavs-types` BLS signer feature build noted in review on #1143.

- Adds Tokio `rt` to the optional `wavs-types` Tokio dependency so `tokio::task::spawn_blocking` is available when `bls` signing is enabled.
- Adds a CI check for `wavs-types` standalone full feature compilation.

## Test plan

- `cargo check -p wavs-types --no-default-features --features full --locked`

Stacked on #1143 (`bls-commonware`).
