### PR TITLE
docs: document block-pinned component reads

### DIFF
--- a/.claude/skills/wavs/SKILL.md
+++ b/.claude/skills/wavs/SKILL.md
@@ -14,6 +14,14 @@ WAVS runs off-chain computation as sandboxed WebAssembly (WASI) components trigg
 
 ---
 
+## Deterministic On-Chain Reads
+
+Treat the trigger/event block height as the canonical snapshot for on-chain data that relates to that trigger. When a component performs EVM, Cosmos, or other RPC reads and the client/API supports it, pass the trigger block number or block height explicitly instead of reading `latest` state.
+
+Avoid mixing historical trigger data with unpinned latest-state reads. Pinning reads to the trigger block improves replayability and prevents nondeterministic state/timestamp mismatches, such as an oracle response whose `updatedAt` appears newer than the block timestamp because an RPC backend served cached state from a different snapshot.
+
+---
+
 ## MCP Setup
 
 The `wavs:` MCP tools below require `wavs-mcp` to be running and registered with Claude Code.

--- a/.claude/skills/wavs/flows/component-dev.md
+++ b/.claude/skills/wavs/flows/component-dev.md
@@ -77,6 +77,8 @@ use example_helpers::trigger::{decode_trigger_event, encode_trigger_output};
 
 ## Host APIs
 
+For on-chain reads related to a trigger, use the trigger's block height as the canonical snapshot. Pass that block number/height to EVM, Cosmos, or RPC calls when supported, and avoid mixing historical trigger data with unpinned `latest` reads.
+
 ```rust
 host::config_var("my-key")               // → Option<String>; reads service config
 host::log(host::LogLevel::Info, "msg");  // levels: Debug, Info, Warn, Error


### PR DESCRIPTION
## Summary
- Add WAVS skill guidance to treat trigger/event block height as the canonical snapshot for related on-chain reads.
- Note that EVM/Cosmos/RPC reads should pass block number/height when supported and avoid mixing historical trigger data with latest-state reads.
- Call out the oracle updatedAt/RPC snapshot mismatch class of bugs.

## Testing
- Docs-only change; no automated tests run.
